### PR TITLE
fix: update plugin_settings to conditionally add drf_spectacular

### DIFF
--- a/corporate_partner_access/settings/common.py
+++ b/corporate_partner_access/settings/common.py
@@ -6,7 +6,11 @@ def plugin_settings(settings):
     Add settings for the corporate_partner_access app.
     """
 
-    settings.INSTALLED_APPS += ["flex_catalog", "drf_spectacular"]
+    settings.INSTALLED_APPS += ["flex_catalog"]
+
+    if "drf_spectacular" not in settings.INSTALLED_APPS:
+        settings.INSTALLED_APPS += ["drf_spectacular"]
+
     settings.REST_FRAMEWORK["DEFAULT_SCHEMA_CLASS"] = "drf_spectacular.openapi.AutoSchema"
     settings.SPECTACULAR_SETTINGS = {
         "TITLE": "Corporate Partner Access API",


### PR DESCRIPTION
This pull request makes a small but important adjustment to how the `drf_spectacular` package is added to the `INSTALLED_APPS` setting. The change ensures that `drf_spectacular` is only added if it is not already present, preventing duplicate entries.

* Prevents duplicate addition of `drf_spectacular` to `INSTALLED_APPS` by checking if it is already included before appending it.