### PR TITLE
[WIP] feat: implement mixins for CSV report generation

### DIFF
--- a/corporate_partner_access/api/v1/mixins.py
+++ b/corporate_partner_access/api/v1/mixins.py
@@ -1,5 +1,13 @@
 """Mixins for corporate_partner_access API v1."""
 
+import csv
+
+from django.http import HttpResponse
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+from corporate_partner_access.api.v1.schemas import report_schema
+
 
 class InjectNestedFKMixin:
     """Generic mixin to inject/override a nested FK id from URL kwargs into serializer data.
@@ -26,3 +34,38 @@ class InjectNestedFKMixin:
             data[self.target_field_name] = self.kwargs[self.nested_lookup_kwarg]
             kwargs["data"] = data
         return super().get_serializer(*args, **kwargs)
+
+
+class ReportMixin:
+    """
+    Mixin to add a 'report' action to a ViewSet that returns a CSV report file.
+    This Mixin expects each view to Override the `report_fields` attribute in order
+    to specify which fields should be included in the report.
+    """
+
+    report_fields = ["id"]
+
+    @report_schema
+    @action(detail=False, methods=["get"], url_path="report")
+    def report(self, request, *args, **kwargs):
+        """Return a CSV file with the selected report fields."""
+
+        queryset = self.filter_queryset(self.get_queryset())
+        serializer = self.get_serializer(queryset, many=True)
+        data = serializer.data
+
+        if not data:
+            return Response({"detail": "No data to report."}, status=400)
+
+        headers = self.report_fields
+        filtered_data = [
+            {field: item.get(field, "") for field in headers} for item in data
+        ]
+
+        response = HttpResponse(content_type="text/csv")
+        response["Content-Disposition"] = 'attachment; filename="report.csv"'
+
+        writer = csv.DictWriter(response, fieldnames=headers)
+        writer.writeheader()
+        writer.writerows(filtered_data)
+        return response

--- a/corporate_partner_access/api/v1/schemas.py
+++ b/corporate_partner_access/api/v1/schemas.py
@@ -270,3 +270,55 @@ def bulk_status_invitations_schema(func):
         },
         tags=["Invitations"]
     )(func)
+
+
+def report_schema(func):
+    """Decorator to document CSV report endpoints.
+
+    Expected behavior:
+      * 200: Returns a CSV file attachment with the selected report fields as columns.
+      * 400: Returns JSON error when there is no data available to export.
+
+    Notes:
+      * The CSV filename is always `report.csv` (may evolve later to be dynamic).
+      * The set & order of columns comes from the view's `report_fields` attribute.
+    """
+    return extend_schema(
+        summary="Download CSV report",
+        description=dedent(
+            """
+            Generate and download a CSV report for the current resource scope.
+
+            The columns included in the CSV are defined by the ViewSet's `report_fields` attribute.
+            Filtering, search, or other query parameters applied to the list endpoint
+            will also affect the dataset exported here.
+
+            Responses:
+            * 200: CSV file (text/csv) attachment named `report.csv`.
+            * 400: JSON error when there is no data to include in the report.
+            """
+        ),
+        responses={
+            200: OpenApiResponse(
+                response=OpenApiTypes.BINARY,
+                description="CSV report generated successfully (text/csv attachment)",
+                examples=[
+                    OpenApiExample(
+                        "CSV Preview (first lines)",
+                        value="id,name\n1,Sample Name\n2,Another\n",
+                    )
+                ],
+            ),
+            400: OpenApiResponse(
+                response=OpenApiTypes.OBJECT,
+                description="No data available to generate report",
+                examples=[
+                    OpenApiExample(
+                        "No Data",
+                        value={"detail": "No data to report."},
+                    )
+                ],
+            ),
+        },
+        tags=["Reports"],
+    )(func)

--- a/corporate_partner_access/api/v1/views.py
+++ b/corporate_partner_access/api/v1/views.py
@@ -12,7 +12,7 @@ from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
 
 from corporate_partner_access.api.v1 import tasks as partner_tasks
-from corporate_partner_access.api.v1.mixins import InjectNestedFKMixin
+from corporate_partner_access.api.v1.mixins import InjectNestedFKMixin, ReportMixin
 from corporate_partner_access.api.v1.schemas import (
     bulk_status_invitations_schema,
     bulk_status_learner_schema,
@@ -98,7 +98,7 @@ class CorporatePartnerViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class CorporatePartnerCatalogViewSet(
-    InjectNestedFKMixin, viewsets.ModelViewSet
+    InjectNestedFKMixin, viewsets.ModelViewSet, ReportMixin
 ):
     """
     ViewSet for Corporate Partner Catalog data.
@@ -122,6 +122,16 @@ class CorporatePartnerCatalogViewSet(
     # Mixin config
     nested_lookup_kwarg = "partner_pk"
     target_field_name = "corporate_partner"
+
+    # Report config
+    report_fields = [
+        "id",
+        "name",
+        "courses",
+        "enrollments",
+        "certified",
+        "completion_rate",
+    ]
 
     def get_queryset(self):
         """Limit catalogs to those the user manages or views; staff see all."""
@@ -246,7 +256,7 @@ class CorporatePartnerCatalogLearnerViewSet(InjectNestedFKMixin, viewsets.ModelV
 
 
 class CorporatePartnerCatalogCourseViewSet(
-    InjectNestedFKMixin, viewsets.ModelViewSet,
+    InjectNestedFKMixin, viewsets.ModelViewSet, ReportMixin
 ):
     """
     ViewSet for Corporate Partner Catalog Course data.
@@ -271,6 +281,17 @@ class CorporatePartnerCatalogCourseViewSet(
     # Mixin config
     nested_lookup_kwarg = "catalog_pk"
     target_field_name = "catalog_id"
+
+    # Report config
+    report_fields = [
+        "id",
+        "name",
+        "position",
+        "course_run",
+        "enrollments",
+        "certified",
+        "completion_rate",
+    ]
 
     def get_queryset(self):
         """Get the queryset for catalog courses."""
@@ -480,7 +501,7 @@ class CatalogCourseEnrollmentAllowedViewSet(
 
 
 class CatalogCourseEnrollmentViewSet(
-    viewsets.ReadOnlyModelViewSet, InjectNestedFKMixin
+    viewsets.ReadOnlyModelViewSet, InjectNestedFKMixin, ReportMixin
 ):
     """
     ViewSet for Catalog Course Enrollments.
@@ -503,6 +524,14 @@ class CatalogCourseEnrollmentViewSet(
     # Mixin config
     nested_lookup_kwarg = "course_pk"
     target_field_name = "catalog_course_id"
+
+    # Report config
+    report_fields = [
+        "user",
+        "completed_assessments",
+        "pending_assessments",
+        "progress",
+    ]
 
     def get_queryset(self):
         """Get the queryset for catalog course enrollments."""


### PR DESCRIPTION
## Description

This pull request introduces reporting functionality for catalogs and courses within a corporate partner context. It adds the necessary attributes and logic to enable counting and reporting of courses and catalogs, enhancing data accessibility and management for corporate partners.

> [!IMPORTANT]
> This PR is currently under revision and may be paused until there is a clear definition of how the reports feature will work in the project. The current implementation is a proposed approach, not yet confirmed.

### Key Changes

* **New Migration:** Adds a migration to facilitate access to intermediate tables from the catalog side (related fields), improving data relationships and queries.
* **Annotations for Counting:** Implements Django ORM annotations to efficiently count courses and catalogs associated with each corporate partner. These counts are now available in the respective serializers, making them accessible via the API.
* **Endpoints for Reports:** Adds dedicated endpoints to download CSV reports for catalogs and courses, supporting data-driven decision-making and external analysis.

### ReportMixin

Introduces a reusable `ReportMixin` that enables CSV report generation for both catalogs and courses. This mixin is designed for extensibility and can be easily reused for future nested resources, such as enrollments or other related entities. It uses the custom view serializer to generate the report data and allows customization through the `report_fields` attribute.

### Mock Data (New)

Introduces new attributes to the Catalog, Partner, and Course serializers, enabling them to mock enrollment, certification, and completion rate statistics.

### New Endpoints

* `GET /partners/<id>/catalogs/report` — Download a CSV report of all catalogs for a given corporate partner.
* `GET /partners/<id>/catalogs/<id>/courses/report` — Download a CSV report of all courses within a specific catalog for a given corporate partner.
* `GET /partners/<id>/catalogs/<id>/courses/<id>/enrollments/report` — Download a CSV report of all enrollments within a specific course for a given corporate partner.

### How to test
1. Visit one of the endpoints to inspect the data:

   * `/partners/<id>/catalogs`
   * `/partners/<id>/catalogs/<id>/courses`
2. Download the report of the verified data via the `/report` endpoints:

   * `/partners/<id>/catalogs/report`
   * `/partners/<id>/catalogs/<id>/courses/report`
   * `/partners/<id>/catalogs/<id>/courses/<id>/enrollments/report`
     This should download a report file with a structure similar to the example shown below.

<img width="894" height="104" alt="image" src="https://github.com/user-attachments/assets/a96cc79b-8b09-4b24-b691-c02a83cc57a1" />  
