### PR TITLE
feat: auto-generate code and slugs on save

### DIFF
--- a/corporate_partner_access/api/v1/serializers.py
+++ b/corporate_partner_access/api/v1/serializers.py
@@ -76,7 +76,7 @@ class CorporatePartnerSerializer(serializers.ModelSerializer):
             "enrollments",
             "certified",
         ]
-        read_only_fields = ["id"]
+        read_only_fields = ["id", "code"]
         extra_kwargs = {
             "homepage_url": {"required": False, "allow_null": True},
             "logo": {"required": False, "allow_null": True, "write_only": True},
@@ -132,7 +132,7 @@ class CorporatePartnerCatalogSerializer(serializers.ModelSerializer):
             "id",
             "email_regexes",
             "courses",
-        ]
+        , "slug"]
         extra_kwargs = {
             "authorization_additional_message": {
                 "required": False,

--- a/corporate_partner_access/api/v1/serializers.py
+++ b/corporate_partner_access/api/v1/serializers.py
@@ -60,7 +60,6 @@ class CorporatePartnerSerializer(serializers.ModelSerializer):
     catalogs = serializers.IntegerField(source="catalogs_count", read_only=True)
     courses = serializers.IntegerField(source="courses_count", read_only=True)
     enrollments = serializers.IntegerField(source="total_enrollments", read_only=True)
-
     certified = serializers.IntegerField(source="certified_count", read_only=True)
 
     class Meta:
@@ -76,7 +75,7 @@ class CorporatePartnerSerializer(serializers.ModelSerializer):
             "enrollments",
             "certified",
         ]
-        read_only_fields = ["id", "code"]
+        read_only_fields = ["id"]
         extra_kwargs = {
             "homepage_url": {"required": False, "allow_null": True},
             "logo": {"required": False, "allow_null": True, "write_only": True},
@@ -101,8 +100,6 @@ class CorporatePartnerCatalogSerializer(serializers.ModelSerializer):
     courses = serializers.IntegerField(source="courses_count", read_only=True)
     enrollments = serializers.IntegerField(source="total_enrollments", read_only=True)
     certified = serializers.IntegerField(source="certified_count", read_only=True)
-
-    # TODO: Replace implementation
     completion_rate = serializers.SerializerMethodField()
 
     class Meta:
@@ -132,7 +129,8 @@ class CorporatePartnerCatalogSerializer(serializers.ModelSerializer):
             "id",
             "email_regexes",
             "courses",
-        , "slug"]
+            "slug",
+        ]
         extra_kwargs = {
             "authorization_additional_message": {
                 "required": False,

--- a/corporate_partner_access/models.py
+++ b/corporate_partner_access/models.py
@@ -42,22 +42,6 @@ class CorporatePartner(models.Model):
         """Return a string representation of the CorporatePartner instance."""
         return f"<CorporatePartner: {self.name} (Code: {self.code})>"
 
-    def save(self, *args, **kwargs):
-        """Save and generate a code for the corporate partner."""
-        current_code = self.code
-
-        if not current_code:
-            name_value = str(self.name or "partner")
-            slug = slugify(name_value)
-            current = CorporatePartner.objects.filter(code__startswith=slug).count()
-
-            if current > 0:
-                slug = f"{slug}-{current + 1}"
-
-            self.code = slug
-
-        super().save(*args, **kwargs)
-
 
 class CorporatePartnerCatalog(FlexibleCatalogModel):
     """Catalog model for corporate partners."""

--- a/corporate_partner_access/models.py
+++ b/corporate_partner_access/models.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models.functions import Lower
+from django.utils.text import slugify
 
 from corporate_partner_access.edxapp_wrapper.course_module import course_overview
 from corporate_partner_access.helpers.current_user import safe_get_current_user
@@ -40,6 +41,22 @@ class CorporatePartner(models.Model):
     def __str__(self):
         """Return a string representation of the CorporatePartner instance."""
         return f"<CorporatePartner: {self.name} (Code: {self.code})>"
+
+    def save(self, *args, **kwargs):
+        """Save and generate a code for the corporate partner."""
+        current_code = self.code
+
+        if not current_code:
+            name_value = str(self.name or "partner")
+            slug = slugify(name_value)
+            current = CorporatePartner.objects.filter(code__startswith=slug).count()
+
+            if current > 0:
+                slug = f"{slug}-{current + 1}"
+
+            self.code = slug
+
+        super().save(*args, **kwargs)
 
 
 class CorporatePartnerCatalog(FlexibleCatalogModel):
@@ -96,6 +113,22 @@ class CorporatePartnerCatalog(FlexibleCatalogModel):
         """Return all catalog course runs associated with this instance."""
         user = safe_get_current_user()
         return CatalogAllowedCoursesService.course_runs_for_user(catalog=self, user=user)
+
+    def save(self, *args, **kwargs):
+        """Save and generate a slug for the corporate partner catalog."""
+        current_slug = self.slug
+
+        if not current_slug:
+            name_value = str(self.name or "catalog")
+            current_slug = slugify(name_value)
+            current = CorporatePartnerCatalog.objects.filter(slug__startswith=current_slug).count()
+
+            if current > 0:
+                current_slug = f"{current_slug}-{current + 1}"
+
+            self.slug = current_slug
+
+        super().save(*args, **kwargs)
 
 
 class CorporatePartnerCatalogEmailRegex(models.Model):
@@ -165,7 +198,9 @@ class CorporatePartnerCatalogCourse(models.Model):
         unique_together = ("catalog", "course_overview")
         ordering = ["position"]
         indexes = [
-            models.Index(fields=["catalog", "course_overview"], name="catalog_course_idx"),
+            models.Index(
+                fields=["catalog", "course_overview"], name="catalog_course_idx"
+            ),
         ]
 
     def __str__(self):
@@ -266,13 +301,11 @@ class CatalogCourseEnrollmentAllowed(models.Model):
     status = models.PositiveSmallIntegerField(
         choices=Status.choices,
         default=Status.SENT,
-        help_text="Status of the course enrollment invitation."
+        help_text="Status of the course enrollment invitation.",
     )
 
     invite_email = models.EmailField(
-        null=True,
-        blank=True,
-        help_text="Invitation email address."
+        null=True, blank=True, help_text="Invitation email address."
     )
 
     invited_at = models.DateTimeField(auto_now_add=True)
@@ -287,7 +320,7 @@ class CatalogCourseEnrollmentAllowed(models.Model):
         null=True,
         blank=True,
         related_name="sent_enrollment_invites",
-        help_text="Who created/sent the invite."
+        help_text="Who created/sent the invite.",
     )
 
     class Meta:
@@ -297,7 +330,9 @@ class CatalogCourseEnrollmentAllowed(models.Model):
         indexes = [
             models.Index(Lower("invite_email"), name="cpcea_email_ci_idx"),
             models.Index(fields=["user"], name="cpcea_user_idx"),
-            models.Index(fields=["catalog_course", "status"], name="cpcea_course_status_idx"),
+            models.Index(
+                fields=["catalog_course", "status"], name="cpcea_course_status_idx"
+            ),
         ]
 
         constraints = [
@@ -307,12 +342,14 @@ class CatalogCourseEnrollmentAllowed(models.Model):
                 condition=models.Q(user__isnull=False),
             ),
             models.UniqueConstraint(
-                Lower("invite_email"), "catalog_course",
+                Lower("invite_email"),
+                "catalog_course",
                 name="cpcea_unique_course_invite_email_ci",
                 condition=models.Q(invite_email__isnull=False),
             ),
             models.CheckConstraint(
-                check=models.Q(user__isnull=False) | models.Q(invite_email__isnull=False),
+                check=models.Q(user__isnull=False)
+                | models.Q(invite_email__isnull=False),
                 name="cpcea_user_or_email_required",
             ),
             models.CheckConstraint(


### PR DESCRIPTION
## Description
This pull request introduces automatic generation of unique `slug` value for  `CorporatePartnerCatalog` model, respectively, to ensure identifiers are set and remain unique. It also updates serializer configurations to make these fields read-only, and includes minor formatting and index improvements for clarity and consistency.

**Automatic identifier generation:**
* Added logic in the `save` method of `CorporatePartnerCatalog` to auto-generate a unique `slug` using a slugified version of the catalog's name if not provided. (`corporate_partner_access/models.py`)

**Serializer updates:**
* Updated  `CorporatePartnerCatalogSerializer` to mark `slug` fields as read-only, preventing manual modification during serialization.