### PR TITLE
refactor: update Catalogs and CatalogCourses API references

### DIFF
--- a/partner_catalog/api/v1/serializers.py
+++ b/partner_catalog/api/v1/serializers.py
@@ -90,10 +90,10 @@ class PartnerSerializer(serializers.ModelSerializer):
         return None
 
 
-class CorporatePartnerCatalogSerializer(serializers.ModelSerializer):
+class PartnerCatalogSerializer(serializers.ModelSerializer):
     """Serializer for Corporate Partner Catalog data."""
 
-    corporate_partner = serializers.PrimaryKeyRelatedField(
+    partner = serializers.PrimaryKeyRelatedField(
         queryset=Partner.objects.all()
     )
 
@@ -101,8 +101,6 @@ class CorporatePartnerCatalogSerializer(serializers.ModelSerializer):
     courses = serializers.IntegerField(source="courses_count", read_only=True)
     enrollments = serializers.IntegerField(source="total_enrollments", read_only=True)
     certified = serializers.IntegerField(source="certified_count", read_only=True)
-
-    # TODO: Replace implementation
     completion_rate = serializers.SerializerMethodField()
 
     class Meta:
@@ -111,18 +109,14 @@ class CorporatePartnerCatalogSerializer(serializers.ModelSerializer):
             "id",
             "name",
             "slug",
-            "corporate_partner",
+            "partner",
             "email_regexes",
-            "course_enrollment_limit",
+            "course_enrollments_limit",
             "user_limit",
             "is_self_enrollment",
             "available_start_date",
             "available_end_date",
-            "custom_courses",
-            "authorization_additional_message",
-            "support_email",
-            "is_public",
-            "catalog_alternative_link",
+            "authorization_message",
             "courses",
             "enrollments",
             "certified",
@@ -132,17 +126,10 @@ class CorporatePartnerCatalogSerializer(serializers.ModelSerializer):
             "id",
             "email_regexes",
             "courses",
+            "slug",
         ]
         extra_kwargs = {
-            "authorization_additional_message": {
-                "required": False,
-                "allow_blank": True,
-            },
-            "support_email": {
-                "required": False,
-                "allow_blank": True,
-            },
-            "catalog_alternative_link": {
+            "authorization_message": {
                 "required": False,
                 "allow_blank": True,
             },
@@ -158,7 +145,7 @@ class CorporatePartnerCatalogSerializer(serializers.ModelSerializer):
         return attrs
 
     def get_email_regexes(self, obj):
-        return list(obj.email_regexes.all().values_list("regex", flat=True))
+        return list(obj.catalog_email_regexes.all().values_list("regex", flat=True))
 
     def get_completion_rate(self, obj):
         rate_statistics = compute_catalog_completion_rate(obj.id)

--- a/partner_catalog/api/v1/urls.py
+++ b/partner_catalog/api/v1/urls.py
@@ -9,7 +9,7 @@ from partner_catalog.api.v1.views import (
     CorporatePartnerCatalogCourseViewSet,
     CorporatePartnerCatalogEmailRegexViewSet,
     CorporatePartnerCatalogLearnerViewSet,
-    CorporatePartnerCatalogViewSet,
+    PartnerCatalogViewSet,
     PartnerViewset,
 )
 
@@ -17,7 +17,7 @@ router = DefaultRouter()
 router.register(r"partners", PartnerViewset, basename="partner")
 
 partners_router = NestedDefaultRouter(router, r"partners", lookup="partner")
-partners_router.register(r"catalogs", CorporatePartnerCatalogViewSet, basename="partner-catalog")
+partners_router.register(r"catalogs", PartnerCatalogViewSet, basename="partner-catalog")
 
 catalogs_router = NestedDefaultRouter(partners_router, r"catalogs", lookup="catalog")
 catalogs_router.register(r"learners", CorporatePartnerCatalogLearnerViewSet, basename="partner-catalog-learners")

--- a/partner_catalog/api/v1/urls.py
+++ b/partner_catalog/api/v1/urls.py
@@ -6,8 +6,8 @@ from rest_framework_nested.routers import NestedDefaultRouter
 
 from partner_catalog.api.v1.views import (
     CatalogCourseEnrollmentViewSet,
-    CorporatePartnerCatalogCourseViewSet,
-    CorporatePartnerCatalogEmailRegexViewSet,
+    CatalogCourseViewSet,
+    CatalogEmailRegexViewSet,
     CorporatePartnerCatalogLearnerViewSet,
     PartnerCatalogViewSet,
     PartnerViewset,
@@ -20,19 +20,13 @@ partners_router = NestedDefaultRouter(router, r"partners", lookup="partner")
 partners_router.register(r"catalogs", PartnerCatalogViewSet, basename="partner-catalog")
 
 catalogs_router = NestedDefaultRouter(partners_router, r"catalogs", lookup="catalog")
-catalogs_router.register(r"learners", CorporatePartnerCatalogLearnerViewSet, basename="partner-catalog-learners")
-catalogs_router.register(r"courses", CorporatePartnerCatalogCourseViewSet, basename="partner-catalog-courses")
-catalogs_router.register(
-    r"email-regexes", CorporatePartnerCatalogEmailRegexViewSet,
-    basename="partner-catalog-email-regexes",
-)
+catalogs_router.register(r"learners", CorporatePartnerCatalogLearnerViewSet, basename="catalog-learners")
+catalogs_router.register(r"courses", CatalogCourseViewSet, basename="catalog-courses")
+catalogs_router.register(r"email_regexes", CatalogEmailRegexViewSet, basename="catalog-email-regexes")
 
 courses_router = NestedDefaultRouter(catalogs_router, r"courses", lookup="course")
-courses_router.register(
-    r"enrollments",
-    CatalogCourseEnrollmentViewSet,
-    basename="partner-catalog-course-enrollments",
-)
+courses_router.register(r"enrollments", CatalogCourseEnrollmentViewSet, basename="catalog-course-enrollments")
+
 urlpatterns = [
     path("", include(router.urls)),
     path("", include(partners_router.urls)),

--- a/partner_catalog/api/v1/views.py
+++ b/partner_catalog/api/v1/views.py
@@ -2,7 +2,6 @@
 
 from celery.result import AsyncResult
 from django.db.models import Count, Q
-from django.db.models.functions import Coalesce
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, status, viewsets
 from rest_framework.decorators import action
@@ -18,7 +17,7 @@ from partner_catalog.api.v1.serializers import (
     CatalogCourseSerializer,
     CatalogEmailRegexSerializer,
     CatalogLearnerSerializer,
-    CorporatePartnerCatalogSerializer,
+    PartnerCatalogSerializer,
     PartnerSerializer,
 )
 from partner_catalog.models import (
@@ -67,7 +66,7 @@ class PartnerViewset(viewsets.ReadOnlyModelViewSet):
         return qs
 
 
-class CorporatePartnerCatalogViewSet(
+class PartnerCatalogViewSet(
     InjectNestedFKMixin, viewsets.ModelViewSet
 ):
     """
@@ -77,21 +76,21 @@ class CorporatePartnerCatalogViewSet(
 
     # pylint: disable=E1111
     queryset = PartnerCatalog.objects.all()
-    serializer_class = CorporatePartnerCatalogSerializer
+    serializer_class = PartnerCatalogSerializer
     permission_classes = [IsPartnerCatalogManager]
     filter_backends = [
         DjangoFilterBackend,
         filters.SearchFilter,
         filters.OrderingFilter,
     ]
-    filterset_fields = ["corporate_partner", "is_public"]
+    filterset_fields = ["partner"]
     search_fields = ["name", "slug"]
     ordering_fields = ["name", "id", "available_start_date", "available_end_date"]
     ordering = ["name"]
 
     # Mixin config
     nested_lookup_kwarg = "partner_pk"
-    target_field_name = "corporate_partner"
+    target_field_name = "partner"
 
     def get_queryset(self):
         """Limit catalogs to those the user manages or views; staff see all."""
@@ -99,7 +98,7 @@ class CorporatePartnerCatalogViewSet(
         user = self.request.user
         partner_pk = self.kwargs.get("partner_pk")
         if partner_pk:
-            qs = qs.filter(corporate_partner_id=partner_pk)
+            qs = qs.filter(partner_id=partner_pk)
 
         if not (user.is_staff or user.is_superuser):
             qs = qs.filter(
@@ -108,15 +107,8 @@ class CorporatePartnerCatalogViewSet(
             ).distinct()
 
         qs = qs.annotate(
-            courses_count=Count("courses", distinct=True),
-            total_enrollments=Coalesce(
-                Count(
-                    "catalog_courses__enrollments",
-                    filter=Q(catalog_courses__enrollments__active=True),
-                    distinct=True,
-                ),
-                0,
-            ),
+            courses_count=Count("catalog_courses", distinct=True),
+            total_enrollments=Count("catalog_learners", distinct=True),
         )
         qs = annotate_catalog_certified_count(qs)
         return qs

--- a/partner_catalog/api/v1/views.py
+++ b/partner_catalog/api/v1/views.py
@@ -207,7 +207,7 @@ class CorporatePartnerCatalogLearnerViewSet(InjectNestedFKMixin, viewsets.ModelV
         return Response(response_data, status=status.HTTP_200_OK)
 
 
-class CorporatePartnerCatalogCourseViewSet(
+class CatalogCourseViewSet(
     InjectNestedFKMixin, viewsets.ModelViewSet,
 ):
     """
@@ -242,7 +242,7 @@ class CorporatePartnerCatalogCourseViewSet(
         qs = qs.filter(catalog_id=catalog_pk) if catalog_pk else qs
 
         partner_pk = self.kwargs.get("partner_pk")
-        qs = qs.filter(catalog__corporate_partner_id=partner_pk) if partner_pk else qs
+        qs = qs.filter(catalog__partner_id=partner_pk) if partner_pk else qs
 
         qs = qs.annotate(
             enrollments_count=Count(
@@ -255,7 +255,7 @@ class CorporatePartnerCatalogCourseViewSet(
         return qs
 
 
-class CorporatePartnerCatalogEmailRegexViewSet(
+class CatalogEmailRegexViewSet(
     InjectNestedFKMixin, viewsets.ModelViewSet
 ):
     """ViewSet for catalog email regex patterns."""


### PR DESCRIPTION
## Description

This pull request refactors the **Catalog, CatalogCourse, and CatalogEmailRegex API** to align with the model name changes from the models refactor.

## Key Changes

### Updated Views (views.py)
- **`PartnerCatalogViewSet`**
- **`CatalogCourseViewSet`**
- **`CatalogEmailRegexViewSet`**

## Available Endpoints

### PartnerCatalog
- `GET /api/v1/partners/{partner_pk}/catalogs/`
- `POST /api/v1/partners/{partner_pk}/catalogs/`
- `GET /api/v1/partners/{partner_pk}/catalogs/{id}/`
- `PUT /api/v1/partners/{partner_pk}/catalogs/{id}/`
- `PATCH /api/v1/partners/{partner_pk}/catalogs/{id}/`
- `DELETE /api/v1/partners/{partner_pk}/catalogs/{id}/`

### CatalogCourse
- `GET /api/v1/partners/{partner_pk}/catalogs/{catalog_pk}/courses/`
- `POST /api/v1/partners/{partner_pk}/catalogs/{catalog_pk}/courses/`
- `GET /api/v1/partners/{partner_pk}/catalogs/{catalog_pk}/courses/{id}/`
- `PUT /api/v1/partners/{partner_pk}/catalogs/{catalog_pk}/courses/{id}/`
- `PATCH /api/v1/partners/{partner_pk}/catalogs/{catalog_pk}/courses/{id}/`
- `DELETE /api/v1/partners/{partner_pk}/catalogs/{catalog_pk}/courses/{id}/`

### CatalogEmailRegex
- `GET /api/v1/partners/{partner_pk}/catalogs/{catalog_pk}/email_regexes/`
- `POST /api/v1/partners/{partner_pk}/catalogs/{catalog_pk}/email_regexes/`
- `GET /api/v1/partners/{partner_pk}/catalogs/{catalog_pk}/email_regexes/{id}/`
- `PUT /api/v1/partners/{partner_pk}/catalogs/{catalog_pk}/email_regexes/{id}/`
- `PATCH /api/v1/partners/{partner_pk}/catalogs/{catalog_pk}/email_regexes/{id}/`
- `DELETE /api/v1/partners/{partner_pk}/catalogs/{catalog_pk}/email_regexes/{id}/`

## Testing

Test the updated endpoints to ensure all CRUD operations work correctly with the new model names.

---