### PR TITLE
feat: add minimal RBAC integration

### DIFF
--- a/partner_catalog/policies/__init__.py
+++ b/partner_catalog/policies/__init__.py
@@ -1,0 +1,1 @@
+"""Corporate partner catalog policies."""

--- a/partner_catalog/policies/rbac.py
+++ b/partner_catalog/policies/rbac.py
@@ -1,0 +1,40 @@
+"""
+RBAC integration for corporate partner catalogs.
+
+This module provides integration with edx-rbac by defining role assignment functions
+that can be registered in SYSTEM_WIDE_ROLE_CLASSES. These functions generate JWT claims
+based on the user's CatalogManager and CatalogLearner assignments.
+
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.db import DatabaseError
+
+from partner_catalog.models import CatalogLearner, CatalogManager
+
+logger = logging.getLogger(__name__)
+
+
+def get_catalog_role_assignments(user):
+    """
+    Generate role assignments for a user based on their catalog relationships.
+
+    This function is designed to be called by edx-rbac's create_role_auth_claim_for_user
+    to populate JWT tokens with catalog-specific roles.
+    """
+
+    if not user or not user.is_authenticated:
+        return
+
+    try:
+        if CatalogManager.objects.filter(user=user, active=True).exists():
+            yield ("catalog_manager", "active")
+
+        if CatalogLearner.objects.filter(user=user, active=True).exists():
+            yield ("catalog_learner", "active")
+    except (DatabaseError, AttributeError) as e:
+        logger.warning(f"Could not retrieve catalog roles for user {user.id}: {e}")
+        return

--- a/partner_catalog/settings/common.py
+++ b/partner_catalog/settings/common.py
@@ -38,3 +38,7 @@ def plugin_settings(settings):
     settings.SEARCH_ENGINE = (
         "partner_catalog.search_engine.FlexibleCatalogCompatibleSearchEngine"
     )
+
+    settings.SYSTEM_WIDE_ROLE_CLASSES = [
+        "partner_catalog.policies.rbac.get_catalog_role_assignments",
+    ]


### PR DESCRIPTION
### Description

This PR introduces role identification for **CatalogManager** and **CatalogLearner** users within the JWT generation flow, leveraging the existing **edx-rbac** integration.
It makes use of the `SYSTEM_WIDE_ROLE_CLASSES` setting to register a custom handler that returns role assignments. When a user authenticates, the `create_role_auth_claim_for_user` function automatically adds these roles to the JWT’s `roles` claim.
This implementation provides a clean way to distinguish user roles, and if needed, can be easily extended to include more granular catalog-specific identification in the future.

### Main changes

* Added the missing `__init__.py` file that was preventing the plugin from installing correctly.
* Added a new `rbac.py` file under the `policies` package containing the role identification logic.
* Updated configuration to include the new handler in `SYSTEM_WIDE_ROLE_CLASSES`, ensuring roles are added to the JWT claims automatically.

### How to test

1. Install the plugin using the `afg/role-identification` branch.
2. In the Django admin panel, assign the desired user as a **CatalogManager** (testing **CatalogLearner** may require an active invitation).
3. Log in to the platform as that user and decode the JWT token you should see a `roles` claim containing an entry like `catalog_manager:active`

<img width="307" height="160" alt="image" src="https://github.com/user-attachments/assets/0b4b8d3d-a770-4668-8df7-3b4ef0348b97" />
