### PR TITLE
feat: implement self-enrollment with invitation handling

### DIFF
--- a/partner_catalog/api/v1/views.py
+++ b/partner_catalog/api/v1/views.py
@@ -37,6 +37,7 @@ from partner_catalog.models import (
     PartnerCatalog,
 )
 from partner_catalog.permissions import IsPartnerCatalogManager
+from partner_catalog.services.catalogs import PartnerCatalogService
 from partner_catalog.services.certificates import (
     annotate_catalog_certified_count,
     annotate_course_certified_count,
@@ -102,6 +103,8 @@ class PartnerCatalogViewSet(
     nested_lookup_kwarg = "partner_pk"
     target_field_name = "partner"
 
+    service = PartnerCatalogService()
+
     def get_queryset(self):
         """Limit catalogs to those the user manages or views; staff see all."""
         qs = self.queryset
@@ -122,6 +125,16 @@ class PartnerCatalogViewSet(
         )
         qs = annotate_catalog_certified_count(qs)
         return qs
+
+    @action(detail=True, methods=["post"], url_path="enroll")
+    def enroll(self, request, *args, **kwargs):
+        """Allow a user to self-enroll in a catalog."""
+        catalog = self.get_object()
+        user = request.user
+
+        learner = self.service.self_enroll_user_in_catalog(user=user, catalog=catalog)
+        serializer = CatalogLearnerSerializer(learner)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 class CatalogLearnerViewset(InjectNestedFKMixin, viewsets.ReadOnlyModelViewSet):

--- a/partner_catalog/consumers.py
+++ b/partner_catalog/consumers.py
@@ -19,7 +19,7 @@ from partner_catalog.events.signals import (
     CATALOG_LEARNER_INVITATION_DECLINED_V1,
     CATALOG_LEARNER_INVITATION_REMOVED_V1,
 )
-from partner_catalog.models import CatalogLearner, CatalogLearnerInvitation
+from partner_catalog.services.catalogs import PartnerCatalogService
 
 logger = logging.getLogger("partner_catalog.events")
 
@@ -49,21 +49,9 @@ def handle_catalog_learner_invitation_accepted(
 ) -> None:
     """Handle acceptance of a CatalogLearnerInvitation."""
     try:
-        learner, created = CatalogLearner.objects.get_or_create(
-            user_id=invitation.user_id,
-            catalog_id=invitation.catalog_id,
-            defaults={'current_invitation_id': invitation.id}
-        )
 
-        # If learner existed but has different invitation, update it
-        if not created and learner.current_invitation_id != invitation.id:
-            learner.current_invitation_id = invitation.id
-            learner.save()
-
-        # Ensure the invitation.learner FK points back to this learner (History Link)
-        invitation_obj = CatalogLearnerInvitation.objects.get(id=invitation.id)
-        invitation_obj.learner = learner
-        invitation_obj.save()
+        catalog_service = PartnerCatalogService()
+        _, created = catalog_service.create_or_update_learner_from_invitation(invitation.id)
 
         logger.info(
             "CATALOG_LEARNER_INVITATION_ACCEPTED: Learner %s for invitation id=%s catalog_id=%s user_id=%s",
@@ -106,16 +94,11 @@ def handle_catalog_learner_invitation_removed(
 ) -> None:
     """Handle removal/revocation of a CatalogLearnerInvitation."""
     try:
-        invitation_obj = CatalogLearnerInvitation.objects.get(id=invitation.id)
-        learner = invitation_obj.learner
+        service = PartnerCatalogService()
+        learner = service.deactivate_learner_from_invitation(invitation.id)
 
-        if not learner:
-            raise ValidationError("No learner associated with this invitation.")
-
-        # This will trigger _compute_active() to deactivate the learner
-        learner.save()
         logger.info(
-            "CL_INVITATION_REMOVED: Learner %s deactivated catalog_id=%s removed_by_id=%s",
+            "CATALOG_LEARNER_INVITATION_REMOVED: Learner %s deactivated catalog_id=%s removed_by_id=%s",
             learner.id,
             invitation.catalog_id,
             invitation.removed_by_id,

--- a/partner_catalog/helpers/regex_cache.py
+++ b/partner_catalog/helpers/regex_cache.py
@@ -7,8 +7,6 @@ patterns. It also provides a cache clearing utility for use in signal handlers o
 administrative actions.
 """
 
-from __future__ import annotations
-
 import functools
 
 import regex
@@ -32,16 +30,15 @@ def compiled_email_regexes_for_catalog(catalog_id: int):
         - Invalid regex patterns are skipped.
     """
     CatalogEmailRegex = apps.get_model(
-        'partner_catalog', 'CorporatePartnerCatalogEmailRegex'
+        'partner_catalog', 'CatalogEmailRegex'
     )
     patterns = (CatalogEmailRegex.objects
                 .filter(catalog_id=catalog_id)
                 .values_list("regex", flat=True))
     compiled = []
-    for p in patterns:
+    for pattern in patterns:
         try:
-            anchored = p if p.startswith("^") or p.endswith("$") else f"^{p}$"
-            compiled.append(regex.compile(anchored, flags=regex.IGNORECASE))
+            compiled.append(regex.compile(pattern, flags=regex.IGNORECASE))
         except regex.error:
             continue
     return tuple(compiled)

--- a/partner_catalog/policies/catalogs.py
+++ b/partner_catalog/policies/catalogs.py
@@ -9,7 +9,7 @@ public catalogs, enrolled learners, and email-based access via regex patterns.
 from __future__ import annotations
 
 from django.apps import apps
-from pydantic_core import ValidationError
+from django.core.exceptions import ValidationError
 
 from partner_catalog.helpers.regex_cache import compiled_email_regexes_for_catalog
 

--- a/partner_catalog/policies/catalogs.py
+++ b/partner_catalog/policies/catalogs.py
@@ -9,6 +9,7 @@ public catalogs, enrolled learners, and email-based access via regex patterns.
 from __future__ import annotations
 
 from django.apps import apps
+from pydantic_core import ValidationError
 
 from partner_catalog.helpers.regex_cache import compiled_email_regexes_for_catalog
 
@@ -33,7 +34,7 @@ def email_matches_catalog(email: str | None, catalog_id: int) -> bool:
     return False
 
 
-def can_user_see_catalog_courses(*, user, catalog) -> bool:
+def can_access_catalog_courses(*, user, catalog) -> bool:
     """
     Determine if a user is allowed to see courses in a given corporate partner catalog.
 
@@ -56,11 +57,107 @@ def can_user_see_catalog_courses(*, user, catalog) -> bool:
         return True
     if not getattr(user, "is_authenticated", False):
         return False
-
-    CatalogLearner = apps.get_model(
-        'partner_catalog', 'CorporatePartnerCatalogLearner'
-    )
-    if CatalogLearner.objects.filter(catalog=catalog, user=user, active=True).exists():
+    if is_user_an_active_catalog_learner(user=user, catalog=catalog):
         return True
 
     return email_matches_catalog(getattr(user, "email", None), catalog.id)
+
+
+def is_user_an_active_catalog_learner(*, user, catalog) -> bool:
+    """
+    Check if the user is an active learner in the specified catalog.
+
+    Args:
+        user: The user object to check.
+        catalog: The catalog instance to check against.
+    Returns:
+        True if the user is an active learner in the catalog, False otherwise.
+    """
+
+    CatalogLearner = apps.get_model("partner_catalog", "CatalogLearner")
+    if not getattr(user, "is_authenticated", False):
+        return False
+
+    return CatalogLearner.objects.filter(
+        catalog=catalog, user=user, active=True
+    ).exists()
+
+
+def has_catalog_capacity(*, catalog) -> bool:
+    """
+    Check if the catalog has remaining capacity for new learners.
+
+    Args:
+        catalog: The catalog instance to check.
+    Returns:
+        True if the catalog has capacity, False if it has reached its limit.
+
+    A catalog is considered to have capacity if:
+        - its user_limit is set to 0 (indicating no limit), or
+        - the current number of active learners is less than the user_limit.
+    """
+
+    CatalogLearner = apps.get_model("partner_catalog", "CatalogLearner")
+    if catalog.user_limit == 0:
+        return True
+
+    current_count = CatalogLearner.objects.filter(catalog=catalog, active=True).count()
+    return current_count < catalog.user_limit
+
+
+def is_catalog_available(*, catalog) -> bool:
+    """
+    Verify if the catalog is currently available.
+
+    Args:
+        catalog: The catalog instance to check.
+
+    Returns:
+        True if the catalog is available, False otherwise.
+
+    A catalog is considered available if:
+        - it is marked as active, and
+        - it has not reached its user capacity limit.
+    """
+    return catalog.active and has_catalog_capacity(catalog=catalog)
+
+
+def can_course_be_added_to_catalog(*, catalog, course) -> bool:  # pylint: disable=unused-argument
+    """
+    Check if a course can be added to the specified catalog based on its active status.
+
+    Args:
+        catalog: The catalog instance to check.
+    Returns:
+        True if the catalog is active, False otherwise.
+
+    A course can be added if:
+        - its part of the catalogs partner(s) offerings or
+        - is listed on the BaseCatalog list.
+    """
+    # TODO: Implement logic to check if a course can be added to the catalog.
+    # A course can be added if its part of the catalogs partner(s) offerings or
+    # is listed on the BaseCatalog list.
+
+    # This functionality was implemented in PR #23 as part of the model clean() method.
+    # Once that is verified, this function can be updated accordingly.
+
+    return True
+
+
+def validate_enrollment_request(*, user, catalog) -> None:
+    """
+    Validate if a user can enroll in the specified catalog.
+
+    Args:
+        user: The user object requesting enrollment.
+        catalog: The catalog instance to enroll in
+    Raises:
+        ValidationError: If the user cannot enroll in the catalog.
+    """
+
+    if not is_catalog_available(catalog=catalog):
+        raise ValidationError("Catalog is not available for enrollment.")
+
+    if not can_access_catalog_courses(user=user, catalog=catalog):
+        raise ValidationError("User is not allowed to enroll in this catalog.")

--- a/partner_catalog/services/allowed_courses.py
+++ b/partner_catalog/services/allowed_courses.py
@@ -9,7 +9,7 @@ based on catalog visibility and user eligibility policies.
 from __future__ import annotations
 
 from partner_catalog.edxapp_wrapper.course_module import course_overview
-from partner_catalog.policies.catalogs import can_user_see_catalog_courses
+from partner_catalog.policies.catalogs import can_access_catalog_courses
 
 
 class CatalogAllowedCoursesService:
@@ -30,7 +30,7 @@ class CatalogAllowedCoursesService:
         Return a queryset of course runs the user can see for the given catalog.
         No selectors: use catalog.courses directly.
         """
-        if can_user_see_catalog_courses(user=user, catalog=catalog):
+        if can_access_catalog_courses(user=user, catalog=catalog):
             return catalog.courses.all()
         return course_overview().objects.none()
 

--- a/partner_catalog/services/catalogs.py
+++ b/partner_catalog/services/catalogs.py
@@ -1,0 +1,109 @@
+"""Service layer for catalog operations."""
+
+from django.contrib.auth import get_user_model
+from django.db import transaction
+from pydantic_core import ValidationError
+
+from partner_catalog.models import CatalogLearner, CatalogLearnerInvitation
+from partner_catalog.policies.catalogs import validate_enrollment_request
+from partner_catalog.services.invitations import CatalogLearnerInvitationService
+
+User = get_user_model()
+
+
+class PartnerCatalogService():
+    """
+    Service layer for partner catalog operations.
+    """
+
+    @transaction.atomic
+    def self_enroll_user_in_catalog(self, user, catalog) -> CatalogLearner:
+        """
+        Enroll the given user in the specified catalog as a CatalogLearner.
+
+        It creates a new invitation and accepts it on behalf of the user, thereby
+        triggering all associated business logic and events.
+
+        Args:
+            user: The user to enroll.
+            catalog: The catalog to enroll the user in.
+        Returns:
+            The created CatalogLearner instance.
+        """
+        # Create the invitation to have record of the Data tracking agreements.
+        invitation_service = CatalogLearnerInvitationService()
+        invitation = invitation_service.create_new_invitation(
+            invite_email=user.email,
+            catalog_id=catalog.id,
+            invited_by=None,
+            emit_event=False
+        )
+        invitation_service.accept_invitation(
+            invitation_id=invitation.id,
+            user=user
+        )
+
+        # Refresh the invitation to get the recently created learner
+        invitation.refresh_from_db()
+        return invitation.learner
+
+    @transaction.atomic
+    def create_or_update_learner_from_invitation(
+        self, invitation_id: int
+    ) -> tuple[CatalogLearner, bool]:
+        """
+        Create or update a CatalogLearner based on a CatalogLearnerInvitation.
+        Args:
+            invitation_id: The ID of the CatalogLearnerInvitation.
+        Returns:
+            A tuple containing the CatalogLearner instance and a boolean indicating
+            whether a new learner was created.
+        """
+
+        invitation = CatalogLearnerInvitation.objects.select_related('catalog').get(
+            id=invitation_id
+        )
+
+        user = User.objects.get(id=invitation.user_id)
+        validate_enrollment_request(
+            catalog=invitation.catalog,
+            user=user
+        )
+
+        learner, created = CatalogLearner.objects.get_or_create(
+            user_id=invitation.user_id,
+            catalog_id=invitation.catalog_id,
+            defaults={'current_invitation_id': invitation.id}
+        )
+
+        # if the learner existed but has previous invitation, update it
+        if not created and learner.current_invitation_id != invitation.id:
+            learner.current_invitation_id = invitation.id
+            learner.save()
+
+        # Link the invitation back to the learner (history tracking)
+        invitation.learner = learner
+        invitation.save(update_fields=['learner'])
+
+        return learner, created
+
+    @transaction.atomic
+    def deactivate_learner_from_invitation(
+        self, invitation_id: int
+    ) -> CatalogLearner:
+        """
+        Deactivate a CatalogLearner based on a CatalogLearnerInvitation.
+        Args:
+            invitation_id: The ID of the CatalogLearnerInvitation.
+        """
+        invitation = CatalogLearnerInvitation.objects.select_related('learner').get(
+            id=invitation_id
+        )
+        learner = invitation.learner
+
+        if not learner:
+            raise ValidationError("No learner associated with this invitation.")
+
+        # This triggers _compute_active() which sets active=False
+        learner.save()
+        return learner

--- a/partner_catalog/services/catalogs.py
+++ b/partner_catalog/services/catalogs.py
@@ -1,8 +1,8 @@
 """Service layer for catalog operations."""
 
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from django.db import transaction
-from pydantic_core import ValidationError
 
 from partner_catalog.models import CatalogLearner, CatalogLearnerInvitation
 from partner_catalog.policies.catalogs import validate_enrollment_request

--- a/partner_catalog/services/invitations.py
+++ b/partner_catalog/services/invitations.py
@@ -57,7 +57,7 @@ class CatalogLearnerInvitationService:
     }
 
     @transaction.atomic
-    def create_new_invitation(self, invite_email: str, catalog_id: int, invited_by=None):
+    def create_new_invitation(self, invite_email: str, catalog_id: int, invited_by=None, emit_event=True):
         """
         Create a new CatalogLearnerInvitation.
         """
@@ -75,7 +75,8 @@ class CatalogLearnerInvitationService:
         except IntegrityError as exc:
             raise ValidationError(self.ERROR_ACTIVE_INVITATION_EXISTS) from exc
 
-        self._emit_invitation_event(invitation)
+        if emit_event:
+            self._emit_invitation_event(invitation)
         return invitation
 
     def _transition_status(

--- a/partner_catalog/signals.py
+++ b/partner_catalog/signals.py
@@ -1,3 +1,17 @@
 """
 Signals for Partner Catalog app.
 """
+
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from partner_catalog.helpers.regex_cache import clear_email_regex_cache
+from partner_catalog.models import CatalogEmailRegex
+
+
+@receiver([post_save, post_delete], sender=CatalogEmailRegex)
+def _invalidate_catalog_regex_cache(sender, instance, **kwargs):  # pylint: disable=unused-argument
+    """
+    Invalidate compiled regex cache when a catalog regex is created/updated/deleted.
+    """
+    clear_email_regex_cache()


### PR DESCRIPTION
## Description

This PR implements a self-enrollment endpoint for the PartnerCatalog API and refactors the codebase to separate business logic validation (policies) from business operations (services).

<img width="2884" height="1168" alt="image" src="https://github.com/user-attachments/assets/cd3bc5b2-3bc0-42a1-b02b-08fcdb7bfefc" />


## Key Changes

### 1. Self-Enrollment Flow
- Added `self_enroll` action to PartnerCatalog API
- Uses `@transaction.atomic` to ensure invitation creation and enrollment happen atomically
> [!Important]
> Creating an invitation record when self enrollment is necessary to ensure we have the user consent for compliance (GDPR/data processing).

### 2. Service Layer
- Introduced `PartnerCatalogService` to centralize catalog operations
- Handles enrollment, learner creation/deactivation from invitations
- All write operations wrapped in transactions

### 3. Policy Layer
- Centralized validation functions (email matching, access control, capacity checks, etc.)
- Pure read-only functions with no database writes
- Used by services to validate before performing operations

### 4. Refactored Signal Consumers
- Moved business logic from `consumers.py` to `PartnerCatalogService`
- Signal handlers now delegate to service methods

### 5. Email Regex Caching
- Re-introduced signal handlers to invalidate cache when `CatalogEmailRegex` changes


## Pending work
- Apply the BaseCatalog validation once #23 gets reviewed.
