### PR TITLE
 refactor: enhance regex cache management and clear functionality

### DIFF
--- a/partner_catalog/helpers/regex_cache.py
+++ b/partner_catalog/helpers/regex_cache.py
@@ -7,14 +7,21 @@ patterns. It also provides a cache clearing utility for use in signal handlers o
 administrative actions.
 """
 
-import functools
+import logging
+from threading import RLock
 
 import regex
+from cachetools import LRUCache, cached
 from django.apps import apps
 
+logger = logging.getLogger(__name__)
 
-@functools.lru_cache(maxsize=1024)
-def compiled_email_regexes_for_catalog(catalog_id: int):
+_regex_cache = LRUCache(maxsize=1024)
+_cache_lock = RLock()
+
+
+@cached(cache=_regex_cache, lock=_cache_lock)
+def compiled_email_regexes_for_catalog(catalog_id: str):
     """
     Retrieve and cache compiled email regex patterns for a given catalog.
 
@@ -23,15 +30,12 @@ def compiled_email_regexes_for_catalog(catalog_id: int):
 
     Returns:
         Tuple of compiled regex patterns (case-insensitive) for the catalog.
-        Patterns are anchored with ^ and $ if not already present.
 
     Notes:
         - Results are cached for performance.
         - Invalid regex patterns are skipped.
     """
-    CatalogEmailRegex = apps.get_model(
-        'partner_catalog', 'CatalogEmailRegex'
-    )
+    CatalogEmailRegex = apps.get_model('partner_catalog', 'CatalogEmailRegex')
     patterns = (CatalogEmailRegex.objects
                 .filter(catalog_id=catalog_id)
                 .values_list("regex", flat=True))
@@ -44,15 +48,21 @@ def compiled_email_regexes_for_catalog(catalog_id: int):
     return tuple(compiled)
 
 
-def clear_email_regex_cache():
+def clear_email_regex_cache(catalog_id: str | None = None):
     """
-    Clear the cache of compiled email regex patterns for all catalogs.
+    Clear the cache of compiled email regex patterns.
+
+    Args:
+        catalog_id: If provided, only clears cache for this specific catalog.
+                   If None, clears cache for all catalogs.
 
     This function should be called when email regex patterns are added, updated,
     or deleted for any catalog, to ensure that subsequent lookups use the latest
     patterns from the database.
 
-    Typical use cases include signal handlers for model changes or administrative
-    actions that modify catalog email regexes.
     """
-    compiled_email_regexes_for_catalog.cache_clear()
+    with _cache_lock:
+        if catalog_id is not None:
+            _regex_cache.pop((catalog_id,), None)
+        else:
+            _regex_cache.clear()

--- a/partner_catalog/policies/catalogs.py
+++ b/partner_catalog/policies/catalogs.py
@@ -14,7 +14,7 @@ from django.core.exceptions import ValidationError
 from partner_catalog.helpers.regex_cache import compiled_email_regexes_for_catalog
 
 
-def email_matches_catalog(email: str | None, catalog_id: int) -> bool:
+def email_matches_catalog(email: str | None, catalog_id: str) -> bool:
     """
     Check if the given email matches any of the compiled regex patterns for the specified catalog.
 

--- a/partner_catalog/signals.py
+++ b/partner_catalog/signals.py
@@ -13,5 +13,7 @@ from partner_catalog.models import CatalogEmailRegex
 def _invalidate_catalog_regex_cache(sender, instance, **kwargs):  # pylint: disable=unused-argument
     """
     Invalidate compiled regex cache when a catalog regex is created/updated/deleted.
+
+    Only invalidates the cache for the specific catalog that was modified.
     """
-    clear_email_regex_cache()
+    clear_email_regex_cache(catalog_id=instance.catalog_id)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -20,3 +20,4 @@ drf-spectacular
 django-crum
 openedx-filters
 openedx-events
+cachetools

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,6 +15,10 @@ attrs==25.3.0
     #   referencing
 billiard==4.2.1
     # via celery
+cachetools==6.2.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 celery==5.5.3
     # via -r requirements/base.in
 certifi==2025.8.3

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,8 +4,10 @@
 #
 #    pip-compile --output-file=requirements/ci.txt requirements/ci.in
 #
-cachetools==6.1.0
-    # via tox
+cachetools==6.2.1
+    # via
+    #   -c requirements/constraints.txt
+    #   tox
 chardet==5.2.0
     # via tox
 colorama==0.4.6

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -18,3 +18,7 @@ click==8.2.1
 # Fix packaging version conflict between pip-tools (24.2) and other requirements (25.0)
 # Using the newer version for consistency across all requirements
 packaging==25.0
+
+# Pin cachetools to avoid version conflicts between tox (6.1.0) and our direct dependency (6.2.1)
+# Using the newer version for better compatibility and features
+cachetools==6.2.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -35,9 +35,11 @@ build==1.2.2.post1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cachetools==6.1.0
+cachetools==6.2.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
     #   tox
 camel-converter[pydantic]==4.0.1
     # via

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -9,6 +9,8 @@ wheel==0.45.1
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
-    # via -r requirements/pip.in
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/pip.in
 setuptools==78.1.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -30,6 +30,10 @@ billiard==4.2.1
     # via
     #   -r requirements/test.txt
     #   celery
+cachetools==6.2.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 camel-converter[pydantic]==4.0.1
     # via
     #   -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -24,6 +24,10 @@ billiard==4.2.1
     # via
     #   -r requirements/base.txt
     #   celery
+cachetools==6.2.1
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
 camel-converter[pydantic]==4.0.1
     # via meilisearch
 celery==5.5.3


### PR DESCRIPTION
## Description

Previously, the email regex compilation cache relied on **functools**, which caused the entire cache for all catalogs to be cleared whenever a new `EmailRegex` entry was added or modified in *any* catalog.

This behavior might be inefficient, i realized that frequent updates at the CatalogEmailRegex models could lead to the cache being invalidated too often.  negating its performance benefits under high traffic or frequent configuration changes.

This update refines the caching mechanism to ensure that **only the relevant catalog’s cache entry is cleared**, instead of flushing the entire cache.
Additionally, proper **thread safety** has been implemented using a lock to prevent race conditions during concurrent access.
