### PR TITLE
feat: implement learner views and serializers for catalog access

### DIFF
--- a/partner_catalog/api/v1/learner_views.py
+++ b/partner_catalog/api/v1/learner_views.py
@@ -78,11 +78,16 @@ class LearnerCatalogViewSet(viewsets.ReadOnlyModelViewSet):
 
     @action(detail=True, methods=["post"], url_path="enroll")
     def enroll(self, request, **kwargs):
-        """Allow a user to self-enroll in a catalog."""
+        """
+        Enroll user in a catalog.
+
+        This action allows an user to enroll in a catalog if they have a valid invitation
+        or if the catalog allows self-enrollment.
+        """
         catalog = self.get_object()
         user = request.user
 
-        learner = self.catalog_service.self_enroll_user_in_catalog(
+        learner = self.catalog_service.enroll_user_in_catalog(
             user=user, catalog=catalog
         )
         serializer = CatalogLearnerSerializer(learner)
@@ -95,18 +100,6 @@ class LearnerCatalogViewSet(viewsets.ReadOnlyModelViewSet):
         user = request.user
 
         learner = self.catalog_service.unenroll_user_from_catalog(
-            user=user, catalog=catalog
-        )
-        serializer = CatalogLearnerSerializer(learner)
-        return Response(serializer.data, status=status.HTTP_200_OK)
-
-    @action(detail=True, methods=["post"], url_path="accept")
-    def accept(self, request, **kwargs):
-        """Accept a pending invitation for this catalog."""
-        catalog = self.get_object()
-        user = request.user
-
-        learner = self.catalog_service.accept_catalog_invitation(
             user=user, catalog=catalog
         )
         serializer = CatalogLearnerSerializer(learner)

--- a/partner_catalog/api/v1/learner_views.py
+++ b/partner_catalog/api/v1/learner_views.py
@@ -1,0 +1,166 @@
+"""Partner Catalog API v1 Learner Views.
+
+These views are intended for regular learners/users to consume catalog data.
+They provide read-only access to catalogs and courses where the user is an active learner.
+"""
+
+from django.db.models import Count, Exists, OuterRef, Q
+from django_filters.rest_framework import DjangoFilterBackend
+from edx_rest_framework_extensions.permissions import IsAuthenticated
+from rest_framework import filters, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+from partner_catalog.api.v1.filters import PartnerCatalogFilter
+from partner_catalog.api.v1.mixins import InjectNestedFKMixin
+from partner_catalog.api.v1.serializers import (
+    CatalogLearnerInvitationSerializer,
+    CatalogLearnerSerializer,
+    LearnerCatalogCourseSerializer,
+    LearnerPartnerCatalogSerializer,
+)
+from partner_catalog.models import CatalogCourse, CatalogLearner, CatalogLearnerInvitation, PartnerCatalog
+from partner_catalog.services.catalogs import PartnerCatalogService
+
+
+class LearnerCatalogViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    ViewSet for learners to view their catalogs.
+
+    Provides read-only access to catalogs where the authenticated user
+    is an active learner. Only shows catalogs that are currently available
+    based on their availability dates.
+    """
+
+    # pylint: disable=E1111
+    queryset = PartnerCatalog.objects.all()
+    serializer_class = LearnerPartnerCatalogSerializer
+    permission_classes = [IsAuthenticated]
+    filterset_class = PartnerCatalogFilter
+    filter_backends = [
+        DjangoFilterBackend,
+        filters.SearchFilter,
+        filters.OrderingFilter,
+    ]
+    search_fields = ["name", "slug"]
+    ordering_fields = ["name", "available_start_date", "available_end_date"]
+    ordering = ["name"]
+
+    catalog_service = PartnerCatalogService()
+
+    def get_queryset(self):
+        """
+        Viewset for catalogs from the perspective of the learner.
+
+        Shows catalogs where:
+            - User is an active learner
+            - User has pending invitations
+            - Catalog allows self-enrollment
+        """
+        user = self.request.user
+
+        is_active_learner = CatalogLearner.objects.filter(
+            catalog=OuterRef("pk"),
+            user=user,
+            active=True,
+        )
+
+        has_pending_invitation = CatalogLearnerInvitation.objects.filter(
+            catalog=OuterRef("pk"),
+            status=CatalogLearnerInvitation.Status.SENT,
+        ).filter(Q(user=user) | Q(invite_email=user.email))
+
+        return self.queryset.filter(
+            Exists(is_active_learner)
+            | Exists(has_pending_invitation)
+            | Q(is_self_enrollment=True)
+        ).annotate(courses_count=Count("catalog_courses", distinct=True))
+
+    @action(detail=True, methods=["post"], url_path="enroll")
+    def enroll(self, request, **kwargs):
+        """Allow a user to self-enroll in a catalog."""
+        catalog = self.get_object()
+        user = request.user
+
+        learner = self.catalog_service.self_enroll_user_in_catalog(
+            user=user, catalog=catalog
+        )
+        serializer = CatalogLearnerSerializer(learner)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @action(detail=True, methods=["post"], url_path="unenroll")
+    def unenroll(self, request, **kwargs):
+        """Allow a user to unenroll from a catalog."""
+        catalog = self.get_object()
+        user = request.user
+
+        learner = self.catalog_service.unenroll_user_from_catalog(
+            user=user, catalog=catalog
+        )
+        serializer = CatalogLearnerSerializer(learner)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @action(detail=True, methods=["post"], url_path="accept")
+    def accept(self, request, **kwargs):
+        """Accept a pending invitation for this catalog."""
+        catalog = self.get_object()
+        user = request.user
+
+        learner = self.catalog_service.accept_catalog_invitation(
+            user=user, catalog=catalog
+        )
+        serializer = CatalogLearnerSerializer(learner)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @action(detail=True, methods=["post"], url_path="decline")
+    def decline(self, request, **kwargs):
+        """Decline a pending invitation for this catalog."""
+        catalog = self.get_object()
+        user = request.user
+
+        invitation = self.catalog_service.decline_catalog_invitation(
+            user=user, catalog=catalog
+        )
+        serializer = CatalogLearnerInvitationSerializer(invitation)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class LearnerCatalogCourseViewSet(InjectNestedFKMixin, viewsets.ReadOnlyModelViewSet):
+    """
+    ViewSet for learners to view courses in their catalogs.
+    """
+
+    queryset = CatalogCourse.objects.select_related("catalog", "course_overview").all()
+    serializer_class = LearnerCatalogCourseSerializer
+    permission_classes = [IsAuthenticated]
+    filter_backends = [
+        DjangoFilterBackend,
+        filters.SearchFilter,
+        filters.OrderingFilter,
+    ]
+    search_fields = ["course_overview__display_name"]
+    ordering_fields = ["position"]
+    ordering = ["position"]
+
+    # Mixin config
+    nested_lookup_kwarg = "catalog_pk"
+    target_field_name = "catalog_id"
+
+    def get_queryset(self):
+        """
+        Queryset of catalog courses from the learners level.
+        """
+        qs = self.queryset
+
+        catalog_pk = self.kwargs.get("catalog_pk")
+
+        if catalog_pk:
+            qs = qs.filter(catalog_id=catalog_pk)
+
+        return qs.annotate(
+            enrollments_count=Count(
+                "enrollments",
+                filter=Q(enrollments__active=True),
+                distinct=True,
+            )
+        )

--- a/partner_catalog/api/v1/serializers.py
+++ b/partner_catalog/api/v1/serializers.py
@@ -397,3 +397,87 @@ class BulkRemoveInvitationSerializer(serializers.Serializer):
     def update(self, instance, validated_data):
         """No-op: this serializer does not mutate instances directly."""
         return instance
+
+
+class LearnerPartnerCatalogSerializer(serializers.ModelSerializer):
+    """
+    Serializer for catalogs from the learner's perspective.
+
+    Provides essential catalog information without management fields.
+    Includes status, enrollment info, and user-specific data.
+    """
+
+    org = serializers.CharField(source="partner.organization.short_name", read_only=True)
+    image = serializers.ImageField(read_only=True)
+    courses = serializers.IntegerField(source="courses_count", read_only=True)
+    enrollments = serializers.IntegerField(source="total_enrollments", read_only=True)
+    status = serializers.SerializerMethodField(read_only=True)
+    is_manager = serializers.SerializerMethodField(read_only=True)
+
+    class Meta:
+        model = PartnerCatalog
+        fields = [
+            "id",
+            "name",
+            "slug",
+            "org",
+            "image",
+            "is_self_enrollment",
+            "available_start_date",
+            "available_end_date",
+            "authorization_message",
+            "user_limit",
+            "course_enrollments_limit",
+            "courses",
+            "enrollments",
+            "status",
+            "is_manager",
+        ]
+        read_only_fields = fields
+
+    def get_status(self, obj):
+        """
+        Check the invitation status for the requesting user on this catalog.
+        """
+        request = self.context.get("request")
+        if not request or not request.user:
+            return None
+
+        return PartnerCatalogService.get_user_catalog_invitation_status(
+            catalog=obj,
+            user=request.user
+        )
+
+    def get_is_manager(self, obj):
+        """
+        Checks if the requesting user is a manager of this catalog.
+        """
+        request = self.context.get("request")
+        if not request or not request.user:
+            return False
+
+        return PartnerCatalogService.is_user_catalog_manager(
+            catalog=obj,
+            user=request.user
+        )
+
+
+class LearnerCatalogCourseSerializer(serializers.ModelSerializer):
+    """
+    Serializer for catalog courses from the learner's perspective.
+    """
+
+    catalog_id = serializers.IntegerField(source="catalog.id", read_only=True)
+    course_run = CourseOverviewSimpleSerializer(source="course_overview", read_only=True)
+    enrollments = serializers.IntegerField(source="enrollments_count", read_only=True)
+
+    class Meta:
+        model = CatalogCourse
+        fields = [
+            "id",
+            "catalog_id",
+            "course_run",
+            "enrollments",
+            "position",
+        ]
+        read_only_fields = fields

--- a/partner_catalog/api/v1/urls.py
+++ b/partner_catalog/api/v1/urls.py
@@ -4,6 +4,7 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 from rest_framework_nested.routers import NestedDefaultRouter
 
+from partner_catalog.api.v1.learner_views import LearnerCatalogCourseViewSet, LearnerCatalogViewSet
 from partner_catalog.api.v1.views import (
     CatalogCourseEnrollmentViewSet,
     CatalogCourseViewSet,
@@ -16,19 +17,24 @@ from partner_catalog.api.v1.views import (
 
 router = DefaultRouter()
 router.register(r"partners", PartnerViewset, basename="partner")
-router.register(r"catalogs", PartnerCatalogViewSet, basename="partner-catalog")
+router.register(r"catalogs", LearnerCatalogViewSet, basename="learner-catalog")
+router.register(r"manage/catalogs", PartnerCatalogViewSet, basename="partner-catalog")
 
 catalogs_router = NestedDefaultRouter(router, r"catalogs", lookup="catalog")
-catalogs_router.register(r"learners", CatalogLearnerViewset, basename="catalog-learners")
-catalogs_router.register(r"courses", CatalogCourseViewSet, basename="catalog-courses")
-catalogs_router.register(r"email_regexes", CatalogEmailRegexViewSet, basename="catalog-email-regexes")
-catalogs_router.register(r"invitations", CatalogLearnerInvitationViewSet, basename="catalog-learner-invitations")
+catalogs_router.register(r"courses", LearnerCatalogCourseViewSet, basename="learner-catalog-courses")
 
-courses_router = NestedDefaultRouter(catalogs_router, r"courses", lookup="course")
+manage_catalogs_router = NestedDefaultRouter(router, r"manage/catalogs", lookup="catalog")
+manage_catalogs_router.register(r"learners", CatalogLearnerViewset, basename="catalog-learners")
+manage_catalogs_router.register(r"courses", CatalogCourseViewSet, basename="catalog-courses")
+manage_catalogs_router.register(r"email_regexes", CatalogEmailRegexViewSet, basename="catalog-email-regexes")
+manage_catalogs_router.register(r"invitations", CatalogLearnerInvitationViewSet, basename="catalog-learner-invitations")
+
+courses_router = NestedDefaultRouter(manage_catalogs_router, r"courses", lookup="course")
 courses_router.register(r"enrollments", CatalogCourseEnrollmentViewSet, basename="catalog-course-enrollments")
 
 urlpatterns = [
     path("", include(router.urls)),
     path("", include(catalogs_router.urls)),
+    path("", include(manage_catalogs_router.urls)),
     path("", include(courses_router.urls)),
 ]

--- a/partner_catalog/services/catalogs.py
+++ b/partner_catalog/services/catalogs.py
@@ -5,7 +5,7 @@ from django.db import transaction
 from rest_framework.exceptions import ValidationError
 
 from partner_catalog.models import CatalogLearner, CatalogLearnerInvitation, CatalogManager
-from partner_catalog.policies.catalogs import validate_catalog_enrollment_request
+from partner_catalog.policies.catalogs import is_user_an_active_catalog_learner, validate_catalog_enrollment_request
 from partner_catalog.services.invitations import CatalogLearnerInvitationService
 
 User = get_user_model()
@@ -18,23 +18,44 @@ class PartnerCatalogService():
 
     ERROR_NOT_PENDING_INVITATION = "No pending invitation found for this catalog."
     ERROR_USER_NOT_ENROLLED = "User is not enrolled in this catalog."
+    ERROR_USER_ALREADY_ENROLLED = "User is already enrolled in this catalog."
 
     @transaction.atomic
-    def self_enroll_user_in_catalog(self, user, catalog) -> CatalogLearner:
+    def enroll_user_in_catalog(self, user, catalog) -> CatalogLearner:
         """
-        Enroll the given user in the specified catalog as a CatalogLearner.
+        Enroll a user in a catalog.
 
-        It creates a new invitation and accepts it on behalf of the user, thereby
-        triggering all associated business logic and events.
+        This method attempts to enroll the user in the specified catalog.
+        It checks for existing enrollment, pending invitations, and self-enrollment settings.
 
         Args:
             user: The user to enroll.
             catalog: The catalog to enroll the user in.
         Returns:
-            The created CatalogLearner instance.
+            The CatalogLearner instance.
+        Raises:
+            ValidationError: If user cannot be enrolled (no invitation and self-enrollment disabled).
         """
-        # Create the invitation to have record of the Data tracking agreements.
+
+        if is_user_an_active_catalog_learner(user=user, catalog=catalog):
+            return ValidationError(self.ERROR_USER_ALREADY_ENROLLED)
+
         invitation_service = CatalogLearnerInvitationService()
+        invitation = invitation_service.get_latest_sent_invitation(
+            user=user, catalog=catalog
+        )
+
+        if invitation:
+            invitation_service.accept_invitation(
+                invitation_id=invitation.id,
+                user=user
+            )
+            invitation.refresh_from_db()
+            return invitation.learner
+
+        if not catalog.is_self_enrollment:
+            raise ValidationError(self.ERROR_NOT_PENDING_INVITATION)
+
         invitation = invitation_service.create_new_invitation(
             invite_email=user.email,
             catalog_id=catalog.id,
@@ -82,37 +103,6 @@ class PartnerCatalogService():
         )
         learner.refresh_from_db()
         return learner
-
-    @transaction.atomic
-    def accept_catalog_invitation(self, user, catalog) -> CatalogLearner:
-        """
-        Accept a pending invitation for a user in a catalog.
-
-        Finds the user's pending invitation and accepts it, creating or updating
-        the CatalogLearner and triggering all associated business logic.
-
-        Args:
-            user: The user accepting the invitation.
-            catalog: The catalog for which to accept the invitation.
-        Returns:
-            The created or updated CatalogLearner instance.
-        Raises:
-            ValidationError: If no pending invitation is found.
-        """
-        invitation_service = CatalogLearnerInvitationService()
-        invitation = invitation_service.get_latest_sent_invitation(
-            user=user, catalog=catalog
-        )
-
-        if not invitation:
-            raise ValidationError(self.ERROR_NOT_PENDING_INVITATION)
-
-        invitation_service.accept_invitation(
-            invitation_id=invitation.id,
-            user=user
-        )
-        invitation.refresh_from_db()
-        return invitation.learner
 
     @transaction.atomic
     def decline_catalog_invitation(self, user, catalog) -> CatalogLearnerInvitation:

--- a/partner_catalog/services/catalogs.py
+++ b/partner_catalog/services/catalogs.py
@@ -4,7 +4,7 @@ from django.contrib.auth import get_user_model
 from django.db import transaction
 from rest_framework.exceptions import ValidationError
 
-from partner_catalog.models import CatalogLearner, CatalogLearnerInvitation
+from partner_catalog.models import CatalogLearner, CatalogLearnerInvitation, CatalogManager
 from partner_catalog.policies.catalogs import validate_catalog_enrollment_request
 from partner_catalog.services.invitations import CatalogLearnerInvitationService
 
@@ -15,6 +15,9 @@ class PartnerCatalogService():
     """
     Service layer for partner catalog operations.
     """
+
+    ERROR_NOT_PENDING_INVITATION = "No pending invitation found for this catalog."
+    ERROR_USER_NOT_ENROLLED = "User is not enrolled in this catalog."
 
     @transaction.atomic
     def self_enroll_user_in_catalog(self, user, catalog) -> CatalogLearner:
@@ -46,6 +49,99 @@ class PartnerCatalogService():
         # Refresh the invitation to get the recently created learner
         invitation.refresh_from_db()
         return invitation.learner
+
+    @transaction.atomic
+    def unenroll_user_from_catalog(self, user, catalog):
+        """
+        Unenroll a user from a catalog by removing their current invitation.
+
+        This will mark the user's current invitation as removed and deactivate
+        the learner, triggering all associated business logic and events.
+
+        Args:
+            user: The user to unenroll.
+            catalog: The catalog to unenroll the user from.
+        Returns:
+            The deactivated CatalogLearner instance.
+        Raises:
+            ValidationError: If the user is not enrolled in the catalog.
+        """
+        learner = CatalogLearner.objects.filter(
+            catalog=catalog,
+            user=user,
+            active=True
+        ).select_related('current_invitation').first()
+
+        if not learner or not learner.current_invitation:
+            raise ValidationError(self.ERROR_USER_NOT_ENROLLED)
+
+        invitation_service = CatalogLearnerInvitationService()
+        invitation_service.remove_invitation(
+            invitation_id=learner.current_invitation.id,
+            user=user
+        )
+        learner.refresh_from_db()
+        return learner
+
+    @transaction.atomic
+    def accept_catalog_invitation(self, user, catalog) -> CatalogLearner:
+        """
+        Accept a pending invitation for a user in a catalog.
+
+        Finds the user's pending invitation and accepts it, creating or updating
+        the CatalogLearner and triggering all associated business logic.
+
+        Args:
+            user: The user accepting the invitation.
+            catalog: The catalog for which to accept the invitation.
+        Returns:
+            The created or updated CatalogLearner instance.
+        Raises:
+            ValidationError: If no pending invitation is found.
+        """
+        invitation_service = CatalogLearnerInvitationService()
+        invitation = invitation_service.get_latest_sent_invitation(
+            user=user, catalog=catalog
+        )
+
+        if not invitation:
+            raise ValidationError(self.ERROR_NOT_PENDING_INVITATION)
+
+        invitation_service.accept_invitation(
+            invitation_id=invitation.id,
+            user=user
+        )
+        invitation.refresh_from_db()
+        return invitation.learner
+
+    @transaction.atomic
+    def decline_catalog_invitation(self, user, catalog) -> CatalogLearnerInvitation:
+        """
+        Decline a pending invitation for a user in a catalog.
+
+        Finds the user's pending invitation and declines it, triggering
+        all associated business logic and events.
+
+        Args:
+            user: The user declining the invitation.
+            catalog: The catalog for which to decline the invitation.
+        Returns:
+            The declined CatalogLearnerInvitation instance.
+        Raises:
+            ValidationError: If no pending invitation is found.
+        """
+        invitation_service = CatalogLearnerInvitationService()
+        invitation = invitation_service.get_latest_sent_invitation(
+            user=user, catalog=catalog
+        )
+
+        if not invitation:
+            raise ValidationError(self.ERROR_NOT_PENDING_INVITATION)
+
+        return invitation_service.decline_invitation(
+            invitation_id=invitation.id,
+            user=user
+        )
 
     @transaction.atomic
     def create_or_update_learner_from_invitation(
@@ -125,7 +221,8 @@ class PartnerCatalogService():
 
         learner = CatalogLearner.objects.filter(
             catalog=catalog,
-            user=user
+            user=user,
+            active=True
         ).select_related('current_invitation').first()
 
         if learner and learner.current_invitation:
@@ -140,3 +237,24 @@ class PartnerCatalogService():
             return invitation.get_status_display()
 
         return None
+
+    @staticmethod
+    def is_user_catalog_manager(catalog, user):
+        """
+        Check if a user is an active manager of a specific catalog.
+
+        Args:
+            catalog: PartnerCatalog instance
+            user: User instance
+
+        Returns:
+            bool: True if user is an active manager, False otherwise
+        """
+        if not user or not user.is_authenticated:
+            return False
+
+        return CatalogManager.objects.filter(
+            catalog=catalog,
+            user=user,
+            active=True
+        ).exists()

--- a/partner_catalog/services/invitations.py
+++ b/partner_catalog/services/invitations.py
@@ -215,7 +215,7 @@ class CatalogLearnerInvitationService:
         """
         Validate if the given user can perform the status transition on the invitation.
         """
-        is_invitation_user = user == invitation.user
+        is_invitation_user = (user == invitation.user or user.email == invitation.invite_email)
         if new_status in [Status.ACCEPTED, Status.DECLINED]:
             return getattr(user, "is_authenticated", False) and is_invitation_user
         elif new_status == Status.REMOVED:


### PR DESCRIPTION
## Description
This pull request reorganizes the catalogs API so we can properly deliver catalog data and actions to the frontend. Learners get the catalog information they need to consume the offering, and managers get a dedicated space to handle configuration.

## Why was this necessary? ⚠️
After giving it some thought, the idea of having a single shared catalogs endpoint didn’t really hold up.

The data we need to expose under `catalogs/...` depends a lot on where we’re calling it from:

- Learning paths MFE → needs catalog info, basic statistics, and catalog courses.
- Dashboard manager MFE → needs more complex statistics, courses, learners, enrollments, and deeper levels of nesting.

Trying to drive all of this through a single nested endpoint would require pretty complex logic to:
- Handle different permission sets.
- Detect where the request is coming from.
- Shape the response accordingly.

Another option was to pack everything into one big serializer, but that doesn’t look great either. Keeping a clear separation of concerns between learners and managers makes the API easier to reason about and maintain.

## Key changes
- Introduced `/manage/catalogs/...` as the manager namespace for catalog admin, stats, seats, learners, and enrollments.
- Kept `/catalogs/...` as the learner-facing endpoints with basic catalog info and courses for the learning paths MFE.
- Replaced `/catalog/<id>/enroll` and `/catalog/<id>/accept` with a single `/enroll` endpoint.
- Added learner endpoints to enroll, unenroll, accept, and decline catalog invitations.
- Removed invitation handling from the manager API.

## How to test
To inspect all endpoints, open the Swagger UI:

- Go to: `http://local.openedx.io:8000/partner_catalog/swagger`
- Confirm:
  - Manager endpoints now live under `/manage/catalogs/...` and still expose the expected manager data.
  - Learner endpoints live under `/catalogs/...` and only expose learner-friendly data (basic stats + courses).

As a manager:
1. Hit a `/manager/catalogs/` endpoint and verify you get catalogs with admin-related data (stats, learners, etc.).

As a learner:
2. Hit `/catalogs/` and `/catalogs/<id>/` and check that you see the simplified catalog representation and its courses.
3. Use the enroll/unenroll/accept/decline endpoints and confirm that:
   - The learner-facing actions work as expected.
   - The manager API is no longer handling invitations.
