### PR TITLE
feat: enhance PartnerCatalogSerializer to support email regexes

### DIFF
--- a/partner_catalog/api/v1/serializers.py
+++ b/partner_catalog/api/v1/serializers.py
@@ -12,7 +12,6 @@ from partner_catalog.edxapp_wrapper.course_module import course_overview
 from partner_catalog.models import (
     CatalogCourse,
     CatalogCourseEnrollment,
-    CatalogEmailRegex,
     CatalogLearner,
     CatalogLearnerInvitation,
     Partner,
@@ -300,19 +299,6 @@ class CatalogCourseSerializer(serializers.ModelSerializer):
     def get_completion_rate(self, obj):
         rate_statistics = compute_catalog_course_completion_rate(obj.id)
         return rate_statistics.get("completion_rate")
-
-
-class CatalogEmailRegexSerializer(serializers.ModelSerializer):
-    """Serializer for catalog email regex patterns."""
-
-    catalog_id = serializers.PrimaryKeyRelatedField(
-        source="catalog", queryset=PartnerCatalog.objects.all()
-    )
-
-    class Meta:
-        model = CatalogEmailRegex
-        fields = ["id", "catalog_id", "regex"]
-        read_only_fields = ["id"]
 
 
 class CatalogLearnerInvitationSerializer(serializers.ModelSerializer):

--- a/partner_catalog/api/v1/serializers.py
+++ b/partner_catalog/api/v1/serializers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.db import transaction
 from rest_framework import serializers
 
 from flex_catalog.serializers import CourseOverviewSimpleSerializer
@@ -100,13 +101,24 @@ class PartnerCatalogSerializer(serializers.ModelSerializer):
     )
 
     image = serializers.ImageField(read_only=True)
-    email_regexes = serializers.SerializerMethodField()
+    email_regexes = serializers.ListField(
+        child=serializers.CharField(max_length=500),
+        required=False,
+        allow_empty=True,
+    )
     org = serializers.SerializerMethodField()
     courses = serializers.IntegerField(source="courses_count", read_only=True)
     enrollments = serializers.IntegerField(source="total_enrollments", read_only=True)
     certified = serializers.IntegerField(source="certified_count", read_only=True)
     completion_rate = serializers.SerializerMethodField()
     status = serializers.SerializerMethodField(read_only=True)
+
+    MANAGER_EDITABLE_FIELDS = [
+        "email_regexes",
+        "authorization_message",
+        "alternative_link",
+        "support_email",
+    ]
 
     class Meta:
         model = PartnerCatalog
@@ -129,10 +141,11 @@ class PartnerCatalogSerializer(serializers.ModelSerializer):
             "org",
             "image",
             "status",
+            "support_email",
+            "alternative_link",
         ]
         read_only_fields = [
             "id",
-            "email_regexes",
             "courses",
             "slug",
             "image",
@@ -153,6 +166,21 @@ class PartnerCatalogSerializer(serializers.ModelSerializer):
             )
         return attrs
 
+    def get_fields(self):
+        fields = super().get_fields()
+        request = self.context.get('request')
+        user = getattr(request, 'user', None)
+
+        if user and (user.is_staff or user.is_superuser):
+            return fields
+
+        if request and request.method in ['PUT', 'PATCH']:
+            for field_name in fields:
+                if field_name not in self.MANAGER_EDITABLE_FIELDS:
+                    fields[field_name].read_only = True
+
+        return fields
+
     def get_org(self, obj):
         return obj.partner.organization.short_name
 
@@ -172,6 +200,21 @@ class PartnerCatalogSerializer(serializers.ModelSerializer):
             catalog=obj,
             user=request.user
         )
+
+    def update(self, instance, validated_data):
+        """Update PartnerCatalog instance, including email regexes."""
+        email_regexes = validated_data.pop('email_regexes', None)
+        with transaction.atomic():
+            instance = super().update(instance, validated_data)
+            if email_regexes is not None:
+                PartnerCatalogService.update_email_regexes(instance, email_regexes)
+
+        return instance
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        data["email_regexes"] = self.get_email_regexes(instance)
+        return data
 
 
 class CatalogLearnerSerializer(serializers.ModelSerializer):

--- a/partner_catalog/api/v1/urls.py
+++ b/partner_catalog/api/v1/urls.py
@@ -8,7 +8,6 @@ from partner_catalog.api.v1.learner_views import LearnerCatalogCourseViewSet, Le
 from partner_catalog.api.v1.views import (
     CatalogCourseEnrollmentViewSet,
     CatalogCourseViewSet,
-    CatalogEmailRegexViewSet,
     CatalogLearnerInvitationViewSet,
     CatalogLearnerViewset,
     PartnerCatalogViewSet,
@@ -26,7 +25,6 @@ catalogs_router.register(r"courses", LearnerCatalogCourseViewSet, basename="lear
 manage_catalogs_router = NestedDefaultRouter(router, r"manage/catalogs", lookup="catalog")
 manage_catalogs_router.register(r"learners", CatalogLearnerViewset, basename="catalog-learners")
 manage_catalogs_router.register(r"courses", CatalogCourseViewSet, basename="catalog-courses")
-manage_catalogs_router.register(r"email_regexes", CatalogEmailRegexViewSet, basename="catalog-email-regexes")
 manage_catalogs_router.register(r"invitations", CatalogLearnerInvitationViewSet, basename="catalog-learner-invitations")
 
 courses_router = NestedDefaultRouter(manage_catalogs_router, r"courses", lookup="course")

--- a/partner_catalog/api/v1/views.py
+++ b/partner_catalog/api/v1/views.py
@@ -19,7 +19,6 @@ from partner_catalog.api.v1.serializers import (
     BulkRemoveInvitationSerializer,
     CatalogCourseEnrollmentSerializer,
     CatalogCourseSerializer,
-    CatalogEmailRegexSerializer,
     CatalogLearnerInvitationSerializer,
     CatalogLearnerSerializer,
     InvitationActionSerializer,
@@ -30,7 +29,6 @@ from partner_catalog.api.v1.tasks import bulk_remove_invitations, bulk_upload_in
 from partner_catalog.models import (
     CatalogCourse,
     CatalogCourseEnrollment,
-    CatalogEmailRegex,
     CatalogLearner,
     CatalogLearnerInvitation,
     Partner,
@@ -230,28 +228,6 @@ class CatalogCourseViewSet(
         )
         qs = annotate_course_certified_count(qs)
         return qs
-
-
-class CatalogEmailRegexViewSet(
-    InjectNestedFKMixin, viewsets.ModelViewSet
-):
-    """ViewSet for catalog email regex patterns."""
-
-    queryset = CatalogEmailRegex.objects.all()
-    serializer_class = CatalogEmailRegexSerializer
-    permission_classes = [IsPartnerCatalogManager]
-    filter_backends = [DjangoFilterBackend]
-    filterset_fields = ["catalog"]
-
-    # Mixin config
-    nested_lookup_kwarg = "catalog_pk"
-    target_field_name = "catalog_id"
-
-    def get_queryset(self):
-        """Get the queryset for catalog email regex patterns."""
-        qs = self.queryset
-        catalog_pk = self.kwargs.get("catalog_pk")
-        return qs.filter(catalog_id=catalog_pk) if catalog_pk else qs
 
 
 class CatalogLearnerInvitationViewSet(

--- a/partner_catalog/api/v1/views.py
+++ b/partner_catalog/api/v1/views.py
@@ -131,7 +131,6 @@ class PartnerCatalogViewSet(viewsets.ModelViewSet):
 
         admin_only_actions = [
             "create",
-            "update",
             "destroy",
         ]
 

--- a/partner_catalog/services/catalogs.py
+++ b/partner_catalog/services/catalogs.py
@@ -1,10 +1,11 @@
 """Service layer for catalog operations."""
 
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from rest_framework.exceptions import ValidationError
 
-from partner_catalog.models import CatalogLearner, CatalogLearnerInvitation, CatalogManager
+from partner_catalog.models import CatalogEmailRegex, CatalogLearner, CatalogLearnerInvitation, CatalogManager
 from partner_catalog.policies.catalogs import is_user_an_active_catalog_learner, validate_catalog_enrollment_request
 from partner_catalog.services.invitations import CatalogLearnerInvitationService
 
@@ -248,3 +249,33 @@ class PartnerCatalogService():
             user=user,
             active=True
         ).exists()
+
+    @staticmethod
+    @transaction.atomic
+    def update_email_regexes(catalog, patterns):
+        """
+        Update email regex patterns for a catalog.
+
+        Args:
+            catalog: PartnerCatalog instance
+            patterns: List of regex pattern strings
+
+        Raises:
+            ValidationError: If any pattern is invalid
+        """
+        existing_regexes = catalog.catalog_email_regexes.all()
+        existing_patterns = set(existing_regexes.values_list('regex', flat=True))
+        new_patterns = set(patterns)
+
+        patterns_to_delete = existing_patterns - new_patterns
+        patterns_to_create = new_patterns - existing_patterns
+
+        if patterns_to_delete:
+            existing_regexes.filter(regex__in=patterns_to_delete).delete()
+
+        for pattern in patterns_to_create:
+            try:
+                email_regex = CatalogEmailRegex(catalog=catalog, regex=pattern)
+                email_regex.save()
+            except DjangoValidationError as exc:
+                raise ValidationError({"email_regexes": exc.messages}) from exc


### PR DESCRIPTION
## Description
This pull request removes the `CatalogEmailRegex` endpoints completely in order to simplify the API, leveraging the PUT/PATCH methods at the catalog level instead.

## Why is this important?
We didn’t really need a full CRUD endpoint just to manage the email regexes assigned to a single catalog.  
Now we can handle the creation and deletion of a catalog’s email regexes through the serializer `update()` function.

I also restricted the manager edit access to only the required attributes, as specified.

## How to test
- Send a `PUT` or `PATCH` request to `/manage/catalogs/<id>/` adding or removing email regex entries.  
  You should see the updated list of email regexes reflected in the response.
- As a manager, try to edit one of the restricted catalog fields (for example `name` or `user_limit`).  
  A validation error should be thrown and the change should be rejected.
