### PR TITLE
feat: add catalog courses service and update policies

### DIFF
--- a/partner_catalog/api/v1/schemas.py
+++ b/partner_catalog/api/v1/schemas.py
@@ -186,3 +186,109 @@ def bulk_status_invitations_schema(func):
         },
         tags=["Invitations"]
     )(func)
+
+
+def add_courses_schema(func):
+    return extend_schema(
+        summary="Add courses to catalog",
+        description=dedent("""
+        Add one or multiple courses to a catalog at a specific position.
+
+        If position is specified, existing courses will be shifted.
+        If position is omitted, courses are appended at the end.
+        """),
+        request={
+            'application/json': {
+                'type': 'object',
+                'properties': {
+                    'course_ids': {
+                        'type': 'array',
+                        'items': {'type': 'string'},
+                        'description': 'List of course IDs to add',
+                        'example': ["course-v1:edX+DemoX+Demo_Course"]
+                    },
+                    'position': {
+                        'type': 'integer',
+                        'description': 'Insert position (optional)',
+                        'nullable': True,
+                        'example': 0
+                    }
+                },
+                'required': ['course_ids']
+            }
+        },
+        responses={
+            201: OpenApiResponse(
+                description="Courses added successfully. Returns list of CatalogCourse objects.",
+                examples=[
+                    OpenApiExample(
+                        'Success',
+                        value=[
+                            {
+                                "id": 1,
+                                "catalog_id": 1,
+                                "position": 0,
+                                "course_run": {
+                                    "id": "course-v1:edX+DemoX+Demo_Course",
+                                    "display_name": "Demo Course"
+                                },
+                                "enrollments": 0,
+                                "certified": 0,
+                                "completion_rate": 0.0
+                            }
+                        ]
+                    )
+                ]
+            ),
+            400: OpenApiResponse(
+                description="Validation error",
+                examples=[
+                    OpenApiExample('Missing Field', value={"course_ids": "This field is required."}),
+                    OpenApiExample('Not Found', value={"detail": "Courses not found: course-v1:edX+Invalid"})
+                ]
+            )
+        },
+        tags=["Catalogs"]
+    )(func)
+
+
+def remove_courses_schema(func):
+    return extend_schema(
+        summary="Remove courses from catalog",
+        description=dedent("""
+        Remove one or multiple courses from a catalog.
+
+        Positions are reorganized automatically after deletion.
+        """),
+        request={
+            'application/json': {
+                'type': 'object',
+                'properties': {
+                    'catalog_course_ids': {
+                        'type': 'array',
+                        'items': {'type': 'integer'},
+                        'description': 'List of CatalogCourse IDs to remove',
+                        'example': [1, 2, 3]
+                    }
+                },
+                'required': ['catalog_course_ids']
+            }
+        },
+        responses={
+            200: OpenApiResponse(
+                response=OpenApiTypes.OBJECT,
+                description="Courses removed successfully",
+                examples=[
+                    OpenApiExample('Success', value={"deleted_count": 3})
+                ]
+            ),
+            400: OpenApiResponse(
+                description="Validation error",
+                examples=[
+                    OpenApiExample('Missing Field', value={"catalog_course_ids": "This field is required."}),
+                    OpenApiExample('Not Found', value={"detail": "CatalogCourse IDs not found: 999"})
+                ]
+            )
+        },
+        tags=["Catalogs"]
+    )(func)

--- a/partner_catalog/api/v1/serializers.py
+++ b/partner_catalog/api/v1/serializers.py
@@ -18,6 +18,7 @@ from partner_catalog.models import (
     PartnerCatalog,
 )
 from partner_catalog.services.assessments import get_assessments_counts
+from partner_catalog.services.catalog_courses import CatalogCourseService
 from partner_catalog.services.catalogs import PartnerCatalogService
 from partner_catalog.services.progress import (
     compute_catalog_completion_rate,
@@ -295,6 +296,25 @@ class CatalogCourseSerializer(serializers.ModelSerializer):
             "completion_rate",
         ]
         read_only_fields = ["id"]
+
+    def get_fields(self):
+        """Make course_overview and catalog_id read-only on update."""
+        fields = super().get_fields()
+
+        if self.instance is not None:
+            fields["course_overview"].read_only = True
+            fields["catalog_id"].read_only = True
+
+        return fields
+
+    def update(self, instance, validated_data):
+        """Update catalog course position if changed."""
+        new_position = validated_data.get("position")
+
+        if new_position is not None and new_position != instance.position:
+            return CatalogCourseService.update_course_position(instance, new_position)
+
+        return super().update(instance, validated_data)
 
     def get_completion_rate(self, obj):
         rate_statistics = compute_catalog_course_completion_rate(obj.id)

--- a/partner_catalog/api/v1/views.py
+++ b/partner_catalog/api/v1/views.py
@@ -11,9 +11,11 @@ from rest_framework.response import Response
 from partner_catalog.api.v1.filters import PartnerCatalogFilter, PartnerFilter
 from partner_catalog.api.v1.mixins import InjectNestedFKMixin
 from partner_catalog.api.v1.schemas import (
+    add_courses_schema,
     bulk_remove_invitations_schema,
     bulk_status_invitations_schema,
     bulk_upload_invitations_schema,
+    remove_courses_schema,
 )
 from partner_catalog.api.v1.serializers import (
     BulkRemoveInvitationSerializer,
@@ -35,6 +37,7 @@ from partner_catalog.models import (
     PartnerCatalog,
 )
 from partner_catalog.permissions import IsPartnerCatalogManager
+from partner_catalog.services.catalog_courses import CatalogCourseService
 from partner_catalog.services.catalogs import PartnerCatalogService
 from partner_catalog.services.certificates import (
     annotate_catalog_certified_count,
@@ -135,6 +138,60 @@ class PartnerCatalogViewSet(viewsets.ModelViewSet):
         if self.action in admin_only_actions:
             return [IsStaff | IsSuperuser]
         return self.permission_classes
+
+    @add_courses_schema
+    @action(detail=True, methods=["post"], url_path="add_courses")
+    def add_courses(self, request, **kwargs):
+        """
+        Add courses to a catalog.
+
+        Expects: {"course_ids": [...], "position": int (optional)}
+        Returns: List of created CatalogCourse instances
+        """
+        catalog = self.get_object()
+        course_ids = request.data.get("course_ids", [])
+        position = request.data.get("position")
+
+        if not course_ids:
+            return Response(
+                {"course_ids": "This field is required."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        created_courses = CatalogCourseService.add_catalog_courses(
+            catalog=catalog,
+            course_overview_ids=course_ids,
+            position=position
+        )
+        serializer = CatalogCourseSerializer(created_courses, many=True)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    @remove_courses_schema
+    @action(detail=True, methods=["post"], url_path="remove_courses")
+    def remove_courses(self, request, **kwargs):
+        """
+        Remove courses from a catalog.
+
+        Expects: {"catalog_course_ids": [...]}
+        Returns: Number of courses deleted
+        """
+        catalog = self.get_object()
+        catalog_course_ids = request.data.get("catalog_course_ids", [])
+
+        if not catalog_course_ids:
+            return Response(
+                {"catalog_course_ids": "This field is required."},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        deleted_count = CatalogCourseService.remove_catalog_courses(
+            catalog=catalog,
+            catalog_course_ids=catalog_course_ids
+        )
+        return Response(
+            {"deleted_count": deleted_count},
+            status=status.HTTP_200_OK
+        )
 
 
 class CatalogLearnerViewset(InjectNestedFKMixin, viewsets.ReadOnlyModelViewSet):

--- a/partner_catalog/api/v1/views.py
+++ b/partner_catalog/api/v1/views.py
@@ -243,7 +243,11 @@ class CatalogLearnerViewset(InjectNestedFKMixin, viewsets.ReadOnlyModelViewSet):
 
 
 class CatalogCourseViewSet(
-    InjectNestedFKMixin, viewsets.ModelViewSet,
+    InjectNestedFKMixin,
+    mixins.RetrieveModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.ListModelMixin,
+    viewsets.GenericViewSet,
 ):
     """
     ViewSet for Corporate Partner Catalog Course data.

--- a/partner_catalog/models.py
+++ b/partner_catalog/models.py
@@ -275,27 +275,6 @@ class CatalogCourse(models.Model):
             ),
         ]
 
-    def clean(self):
-        """Validate that the course is part of the partner course offerings or base catalog."""
-        super().clean()
-
-        # Check if the course is in the base catalog
-        base_catalog = BaseCatalog.get_instance()
-        if base_catalog.get_course_runs().filter(id=self.course_overview_id).exists():
-            return
-
-        # Check if the course belongs to the partner's organization
-        organization = self.catalog.partner.organization
-        course_org = self.course_overview.org
-
-        if organization.short_name != course_org:
-            raise ValidationError({"course_overview": "Course is not part of the partner's offerings."})
-
-    def save(self, *args, **kwargs):
-        """Ensure clean is called before saving."""
-        self.clean()
-        super().save(*args, **kwargs)
-
     def __str__(self):
         """Return string representation of the CatalogCourse instance."""
         return (

--- a/partner_catalog/policies/catalogs.py
+++ b/partner_catalog/policies/catalogs.py
@@ -12,7 +12,7 @@ from django.apps import apps
 from django.core.exceptions import ValidationError
 
 from partner_catalog.helpers.regex_cache import compiled_email_regexes_for_catalog
-from partner_catalog.models import CatalogLearnerInvitation
+from partner_catalog.models import BaseCatalog, CatalogLearnerInvitation
 
 Status = CatalogLearnerInvitation.Status
 
@@ -125,7 +125,7 @@ def is_catalog_available(*, catalog) -> bool:
     return catalog.active and has_catalog_capacity(catalog=catalog)
 
 
-def can_course_be_added_to_catalog(*, catalog, course) -> bool:  # pylint: disable=unused-argument
+def can_course_be_added_to_catalog(*, catalog, course) -> bool:
     """
     Check if a course can be added to the specified catalog based on its active status.
 
@@ -138,13 +138,16 @@ def can_course_be_added_to_catalog(*, catalog, course) -> bool:  # pylint: disab
         - its part of the catalogs partner(s) offerings or
         - is listed on the BaseCatalog list.
     """
-    # TODO: Implement logic to check if a course can be added to the catalog.
-    # A course can be added if its part of the catalogs partner(s) offerings or
-    # is listed on the BaseCatalog list.
+    base_catalog = BaseCatalog.get_instance()
 
-    # This functionality was implemented in PR #23 as part of the model clean() method.
-    # Once that is verified, this function can be updated accordingly.
+    if base_catalog.get_course_runs().filter(id=course.id).exists():
+        return True
 
+    catalog_org = catalog.partner.organization
+    course_org = course.org
+
+    if catalog_org.short_name != course_org:
+        return False
     return True
 
 

--- a/partner_catalog/services/catalog_courses.py
+++ b/partner_catalog/services/catalog_courses.py
@@ -1,0 +1,172 @@
+"""Service layer for catalog course operations."""
+
+from django.db import transaction
+from django.db.models import F
+from rest_framework.exceptions import ValidationError
+
+from partner_catalog.edxapp_wrapper.course_module import course_overview as CourseOverviewModel
+from partner_catalog.models import CatalogCourse
+from partner_catalog.policies.catalogs import can_course_be_added_to_catalog
+
+CourseOverview = CourseOverviewModel()
+
+
+class CatalogCourseService:
+    """Service layer for managing catalog courses."""
+
+    @staticmethod
+    @transaction.atomic
+    def add_catalog_courses(catalog, course_overview_ids, position=None):
+        """
+        Add one or multiple courses to a catalog at a specific position.
+
+        Args:
+            catalog: PartnerCatalog instance
+            course_overview_ids: Single course ID string or list of course ID strings
+            position: Position where courses will be inserted (None = append at end)
+
+        Returns:
+            List of created CatalogCourse instances
+
+        Raises:
+            ValidationError: If any course doesn't exist or validation fails
+        """
+        if isinstance(course_overview_ids, str):
+            course_overview_ids = [course_overview_ids]
+
+        valid_course_ids = CourseOverview.objects.filter(
+            id__in=course_overview_ids
+        ).values_list("id", flat=True)
+
+        if valid_course_ids.count() != len(course_overview_ids):
+            found_ids = set(valid_course_ids)
+            missing_ids = set(course_overview_ids) - found_ids
+            raise ValidationError(
+                {"course_ids": f"Courses not found: {', '.join(missing_ids)}"}
+            )
+
+        courses_to_add = len(course_overview_ids)
+        if position is None:
+            position = CatalogCourse.objects.filter(catalog=catalog).count()
+
+        CatalogCourse.objects.filter(catalog=catalog, position__gte=position).update(
+            position=F("position") + courses_to_add
+        )
+
+        created_courses = []
+        for idx, course_id in enumerate(course_overview_ids):
+            course_overview = CourseOverview.objects.get(id=course_id)
+
+            try:
+                if not can_course_be_added_to_catalog(
+                    catalog=catalog, course=course_overview
+                ):
+                    raise ValidationError(
+                        {"course_ids": f"Course {course_id} cannot be added to this catalog."}
+                    )
+                catalog_course = CatalogCourse(
+                    catalog=catalog,
+                    course_overview=course_overview,
+                    position=position + idx,
+                )
+                catalog_course.save()
+                created_courses.append(catalog_course)
+            except Exception as exc:
+                raise ValidationError(
+                    {"course_ids": f"Error adding course {course_id}: {exc}"}
+                ) from exc
+
+        return created_courses
+
+    @staticmethod
+    @transaction.atomic
+    def remove_catalog_courses(catalog, catalog_course_ids):
+        """
+        Remove one or multiple catalog courses and reorganize positions.
+
+        Args:
+            catalog: PartnerCatalog instance
+            catalog_course_ids: Single CatalogCourse ID or list of CatalogCourse IDs
+
+        Returns:
+            int: Number of courses deleted
+
+        Raises:
+            ValidationError: If any CatalogCourse doesn't exist in the catalog
+        """
+        if isinstance(catalog_course_ids, int):
+            catalog_course_ids = [catalog_course_ids]
+
+        courses_to_delete = CatalogCourse.objects.filter(
+            catalog=catalog, id__in=catalog_course_ids
+        )
+
+        if courses_to_delete.count() != len(catalog_course_ids):
+            found_ids = set(courses_to_delete.values_list("id", flat=True))
+            missing_ids = set(catalog_course_ids) - found_ids
+            raise ValidationError(
+                {"catalog_courses": f"CatalogCourse IDs not found: {', '.join(map(str, missing_ids))}"}
+            )
+
+        try:
+            deleted_count, _ = courses_to_delete.delete()
+        except Exception as exc:
+            raise ValidationError(
+                {"catalog_courses": f"Error deleting catalog courses: {str(exc)}"}
+            ) from exc
+
+        CatalogCourseService._reorganize_positions(catalog)
+        return deleted_count
+
+    @staticmethod
+    @transaction.atomic
+    def update_course_position(catalog_course, new_position):
+        """
+        Update a course position and reorganize other courses accordingly.
+
+        Args:
+            catalog_course: CatalogCourse instance to update
+            new_position: New position for the course
+        """
+        old_position = catalog_course.position
+
+        if old_position == new_position:
+            return catalog_course
+
+        catalog = catalog_course.catalog
+
+        if new_position < old_position:
+            CatalogCourse.objects.filter(
+                catalog=catalog, position__gte=new_position, position__lt=old_position
+            ).update(position=F("position") + 1)
+        else:
+            CatalogCourse.objects.filter(
+                catalog=catalog, position__gt=old_position, position__lte=new_position
+            ).update(position=F("position") - 1)
+
+        catalog_course.position = new_position
+        catalog_course.save(update_fields=["position"])
+
+        return catalog_course
+
+    @staticmethod
+    @transaction.atomic
+    def _reorganize_positions(catalog):
+        """
+        Reorganize all course positions sequentially starting from 0.
+
+        Args:
+            catalog: PartnerCatalog instance
+        """
+        courses = list(
+            CatalogCourse.objects.filter(catalog=catalog).order_by("position")
+        )
+
+        courses_to_update = []
+        for idx, course in enumerate(courses):
+            if course.position != idx:
+                course.position = idx
+                courses_to_update.append(course)
+
+        if courses_to_update:
+            CatalogCourse.objects.bulk_update(courses_to_update, ["position"])


### PR DESCRIPTION
## Description
This pull request adds all the necessary logic to add and remove courses from a catalog.  
It introduces a new `catalog_course` service that handles course position ordering, bulk additions, and bulk removals of courses in a catalog.

## Key changes
- Added two new endpoints to manage catalog courses:
  - `POST /manage/catalogs/<id>/add_courses`
  - `POST /manage/catalogs/<id>/remove_courses`
- Created two new schemas to document how to use both endpoints.
- Added the necessary policy checks to validate that new catalog course additions are valid, complying with the organization logic and base catalog logic.
- Removed the `POST` (create) catalog course from the `CatalogCourseEnrollmentView`, since all catalog course additions will now go through the `/add_courses` endpoint.
- Updated the `PATCH`/`PUT` endpoint at `/manage/catalogs/<catalog_id>/courses/<course_id>` to allow updating the position of a single course within a catalog.

## How to test
1. Go to the Swagger UI  `http://local.openedx.io:8000/partner_catalog/swagger`
2. Call `POST /manage/catalogs/<id>/add_courses` with a list of valid course IDs that belong to the catalog’s organization.
   - Verify in the response that the courses are now listed under that catalog.
3. Try adding a course that does **not** belong to the catalog’s organization:
   - The request should fail with a validation/policy error.
4. Call `POST /manage/catalogs/<id>/remove_courses` with one or more course IDs already associated.
   - Verify that those courses are removed from the catalog in the response.
5. Use `PATCH` or `PUT` on `/manage/catalogs/<catalog_id>/courses/<course_id>`:
   - Update the `position` field of a course.
   - Verify that the new position is reflected in the response.