### PR TITLE
fix: update catalog enrollment attributes

### DIFF
--- a/partner_catalog/api/v1/serializers.py
+++ b/partner_catalog/api/v1/serializers.py
@@ -108,7 +108,9 @@ class PartnerCatalogSerializer(serializers.ModelSerializer):
     )
     org = serializers.SerializerMethodField()
     courses = serializers.IntegerField(source="courses_count", read_only=True)
-    enrollments = serializers.IntegerField(source="total_enrollments", read_only=True)
+    enrollments = serializers.IntegerField(read_only=True)
+    total_learners = serializers.IntegerField(read_only=True)
+    active_learners = serializers.IntegerField(read_only=True)
     certified = serializers.IntegerField(source="certified_count", read_only=True)
     completion_rate = serializers.SerializerMethodField()
     status = serializers.SerializerMethodField(read_only=True)
@@ -136,6 +138,8 @@ class PartnerCatalogSerializer(serializers.ModelSerializer):
             "authorization_message",
             "courses",
             "enrollments",
+            "total_learners",
+            "active_learners",
             "certified",
             "completion_rate",
             "org",

--- a/partner_catalog/api/v1/views.py
+++ b/partner_catalog/api/v1/views.py
@@ -122,7 +122,9 @@ class PartnerCatalogViewSet(viewsets.ModelViewSet):
 
         qs = qs.annotate(
             courses_count=Count("catalog_courses", distinct=True),
-            total_enrollments=Count("catalog_learners", distinct=True),
+            enrollments=Count("catalog_courses__enrollments", distinct=True),
+            total_learners=Count("catalog_learners", distinct=True),
+            active_learners=Count("catalog_learners", filter=Q(catalog_learners__active=True), distinct=True),
         )
         qs = annotate_catalog_certified_count(qs)
         return qs


### PR DESCRIPTION
## Description
This pull request adjusts the catalog serializer to refine how learner and enrollment data is exposed. This was necessary in order to calculate the current seats available per catalog.

## Key changes
- `enrollments`: now returns all catalog course enrollments created for the catalog (previously it was exposed as a simple learner count).
- `active_learners`: exposes the count of active learners in the catalog.
- `total_learners`: exposes the total number of learners in the catalog (active + inactive).
