### PR TITLE
feat: update lookup fields for course overview at catalog courses

### DIFF
--- a/partner_catalog/api/v1/learner_views.py
+++ b/partner_catalog/api/v1/learner_views.py
@@ -140,6 +140,9 @@ class LearnerCatalogCourseViewSet(InjectNestedFKMixin, viewsets.ReadOnlyModelVie
     nested_lookup_kwarg = "catalog_pk"
     target_field_name = "catalog_id"
 
+    lookup_field = "course_overview_id"
+    lookup_url_kwarg = "course_id"
+
     enrollment_service = CatalogCourseEnrollmentService()
 
     def get_queryset(self):

--- a/partner_catalog/api/v1/views.py
+++ b/partner_catalog/api/v1/views.py
@@ -311,6 +311,9 @@ class CatalogCourseViewSet(
     nested_lookup_kwarg = "catalog_pk"
     target_field_name = "catalog_id"
 
+    lookup_field = "course_overview_id"
+    lookup_url_kwarg = "course_id"
+
     def get_queryset(self):
         """Get the queryset for catalog courses."""
         qs = self.queryset


### PR DESCRIPTION
## Description
This pull request updates the URL convention used to identify catalog courses within a catalog.

## Key changes
- Changed the catalog course URL lookup to use the current CourseOverview id (Open edX course key).
- URLs like `/manage/catalogs/<id>/courses/<id>/` will now be `/manage/catalogs/<id>/courses/<course_key>/`.

## How to test
1. Make sure you have a catalog with courses already associated.
2. Go to the `partner_catalog` Swagger UI and locate the following endpoints:
   - `GET /manage/catalogs/{catalog_id}/courses/`
   - `GET /manage/catalogs/{catalog_id}/courses/{course_key}/`
3. Take a valid `course_key` from the catalog courses list (e.g. `course-v1:ORG+CODE+RUN`).
4. Call:
   - `GET /manage/catalogs/<catalog_id>/courses/<course_key>/`  
   and verify the expected course is returned correctly.
