### PR TITLE
fix: correct course_id type in enrollment retrieval

### DIFF
--- a/partner_catalog/policies/enrollments.py
+++ b/partner_catalog/policies/enrollments.py
@@ -45,6 +45,6 @@ def has_an_edx_platform_enrollment(*, user_id: int, course_id) -> bool:
 
     User = get_user_model()
     user = User.objects.only("id", "username").get(pk=user_id)
-    enrollment = get_enrollment(username=user.username, course_id=course_id)
+    enrollment = get_enrollment(username=user.username, course_id=str(course_id))
 
     return enrollment is not None


### PR DESCRIPTION
## Description
This pull request makes a minor adjustment to the way course IDs are handled when fetching enrollments. Specifically, it ensures that the `course_id` parameter is always passed as a string to the `get_enrollment` function, which can help prevent potential type-related issues.

- Always convert `course_id` to a string when calling `get_enrollment` in `has_an_edx_platform_enrollment` to ensure consistent parameter types.