### PR TITLE
fix: add a new exception & filter inactive enrollments

### DIFF
--- a/partner_catalog/api/v1/views.py
+++ b/partner_catalog/api/v1/views.py
@@ -125,10 +125,10 @@ class PartnerCatalogViewSet(viewsets.ModelViewSet):
         qs = qs.annotate(
             courses_count=Count("catalog_courses", distinct=True),
             enrollments=Count(
-				"catalog_courses__enrollments",
-				filter=Q(catalog_courses__enrollments__active=True),
-				distinct=True
-			),
+                "catalog_courses__enrollments",
+                filter=Q(catalog_courses__enrollments__active=True),
+                distinct=True
+            ),
             total_learners=Count("catalog_learners", distinct=True),
             active_learners=Count("catalog_learners", filter=Q(catalog_learners__active=True), distinct=True),
         )

--- a/partner_catalog/api/v1/views.py
+++ b/partner_catalog/api/v1/views.py
@@ -124,7 +124,11 @@ class PartnerCatalogViewSet(viewsets.ModelViewSet):
 
         qs = qs.annotate(
             courses_count=Count("catalog_courses", distinct=True),
-            enrollments=Count("catalog_courses__enrollments", distinct=True),
+            enrollments=Count(
+				"catalog_courses__enrollments",
+				filter=Q(catalog_courses__enrollments__active=True),
+				distinct=True
+			),
             total_learners=Count("catalog_learners", distinct=True),
             active_learners=Count("catalog_learners", filter=Q(catalog_learners__active=True), distinct=True),
         )

--- a/partner_catalog/exceptions.py
+++ b/partner_catalog/exceptions.py
@@ -9,6 +9,13 @@ class CatalogEnrollmentError(APIException):
     default_code = "catalog_enrollment_error"
     default_detail = "Catalog enrollment error."
 
+class InactiveCatalogEnrollment(CatalogEnrollmentError):
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_code = "catalog_unavailable"
+    default_detail = (
+		"The catalog is not currently available. "
+		"It can only be accessed within its configured availability period."
+	)
 
 class NotAllowedToEnroll(CatalogEnrollmentError):
     status_code = status.HTTP_403_FORBIDDEN

--- a/partner_catalog/exceptions.py
+++ b/partner_catalog/exceptions.py
@@ -9,13 +9,15 @@ class CatalogEnrollmentError(APIException):
     default_code = "catalog_enrollment_error"
     default_detail = "Catalog enrollment error."
 
+
 class InactiveCatalogEnrollment(CatalogEnrollmentError):
     status_code = status.HTTP_400_BAD_REQUEST
     default_code = "catalog_unavailable"
     default_detail = (
-		"The catalog is not currently available. "
-		"It can only be accessed within its configured availability period."
-	)
+        "The catalog is not currently available. "
+        "It can only be accessed within its configured availability period."
+    )
+
 
 class NotAllowedToEnroll(CatalogEnrollmentError):
     status_code = status.HTTP_403_FORBIDDEN

--- a/partner_catalog/policies/catalogs.py
+++ b/partner_catalog/policies/catalogs.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from django.apps import apps
 from django.core.exceptions import ValidationError
 
-from partner_catalog.exceptions import UserLimitReached, InactiveCatalogEnrollment
+from partner_catalog.exceptions import InactiveCatalogEnrollment, UserLimitReached
 from partner_catalog.helpers.regex_cache import compiled_email_regexes_for_catalog
 from partner_catalog.models import BaseCatalog, CatalogLearnerInvitation
 

--- a/partner_catalog/policies/catalogs.py
+++ b/partner_catalog/policies/catalogs.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from django.apps import apps
 from django.core.exceptions import ValidationError
 
-from partner_catalog.exceptions import UserLimitReached
+from partner_catalog.exceptions import UserLimitReached, InactiveCatalogEnrollment
 from partner_catalog.helpers.regex_cache import compiled_email_regexes_for_catalog
 from partner_catalog.models import BaseCatalog, CatalogLearnerInvitation
 
@@ -167,7 +167,7 @@ def validate_catalog_enrollment_request(*, invitation) -> None:
         raise ValidationError("Invitation must be accepted to enroll in the catalog.")
 
     if not invitation.catalog.active:
-        raise ValidationError("Catalog is not available for enrollment.")
+        raise InactiveCatalogEnrollment()
 
     CatalogLearner = apps.get_model("partner_catalog", "CatalogLearner")
     already_active = CatalogLearner.objects.filter(


### PR DESCRIPTION
This PR adds a new exception to manage expired catalogs and filters the inactive enrollments to show the correct enrollment count

### Screenshots
- Show message for expired catalogs
    <img width="1856" height="1053" alt="image" src="https://github.com/user-attachments/assets/dd644ece-ebaf-4aff-bc90-e6481f17d67e" />

- Filter inactive enrollments
    | Before | After |
    |----------|---------|
    | <img width="1612" height="731" alt="image" src="https://github.com/user-attachments/assets/377f91f9-a83e-42f7-bb14-77e046901aef" /> | <img width="1587" height="698" alt="image" src="https://github.com/user-attachments/assets/e469cf4d-c27a-4913-9961-377ef264ff11" /> |

