### PR TITLE
fix: change audit to verified when enrolling a catalog

### DIFF
--- a/partner_catalog/consumers.py
+++ b/partner_catalog/consumers.py
@@ -21,6 +21,8 @@ from partner_catalog.events.signals import (
 )
 from partner_catalog.services.catalogs import PartnerCatalogService
 from partner_catalog.services.enrollments import CatalogCourseEnrollmentService
+from partner_catalog.services.enrollments import CatalogCourseEnrollmentService
+from partner_catalog.models import CatalogCourse
 
 logger = logging.getLogger("partner_catalog.events")
 
@@ -53,6 +55,22 @@ def handle_catalog_learner_invitation_accepted(
 
         catalog_service = PartnerCatalogService()
         _, created = catalog_service.create_or_update_learner_from_invitation(invitation.id)
+
+        enrollment_service = CatalogCourseEnrollmentService()
+        catalog_courses = CatalogCourse.objects.filter(catalog_id=invitation.catalog_id)
+
+        for catalog_course in catalog_courses:
+            try:
+                enrollment_service.create_or_activate_course_enrollment(
+                    user_id=invitation.user_id,
+                    catalog_course_id=catalog_course.id,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed syncing catalog course enrollment user_id=%s catalog_course_id=%s",
+                    invitation.user_id,
+                    catalog_course.id,
+                )
 
         logger.info(
             "CATALOG_LEARNER_INVITATION_ACCEPTED: Learner %s for invitation id=%s catalog_id=%s user_id=%s",


### PR DESCRIPTION
This PR runs `create_or_activate_course_enrollment` for every course the user is already enrolled in, changing the course mode from `audit` to `verified`. This fills a seat in the catalog, creates a registry in `Catalog Course Enrollment` properly, and ensures the change of mode for all the previous enrollments

### Limitations

When there are not enough seats, there is no proper behavior defined

### Screencast
[Screencast from 10-03-26 16:50:51.webm](https://github.com/user-attachments/assets/239e68b6-1fc4-446d-94ee-926ffc1ac33f)
