### PR TITLE
fix: correct catalog url building

### DIFF
--- a/partner_catalog/utils/urls.py
+++ b/partner_catalog/utils/urls.py
@@ -6,7 +6,7 @@ from django.conf import settings
 def build_catalog_url(partner_slug: str, catalog_slug: str) -> str:
     """Build a URL to the corporate catalogs MFE for given partner and catalog slugs.
 
-    Result: {BASE_URL}/corporate-catalogs/catalog/<partner_slug>/<catalog_slug>
+    Result: {BASE_URL}/<partner_slug>/catalog/<catalog_slug>
     BASE_URL comes from `settings.CORPORATE_CATALOGS_MFE_BASE_URL`.
     If not configured, returns a relative path.
     """
@@ -14,4 +14,4 @@ def build_catalog_url(partner_slug: str, catalog_slug: str) -> str:
     if not base:
         base = getattr(settings, "LMS_ROOT_URL", "").rstrip("/")
     base = base.rstrip("/")
-    return f"{base}/corporate-catalogs/catalog/{partner_slug}/{catalog_slug}"
+    return f"{base}/{partner_slug}/catalog/{catalog_slug}"


### PR DESCRIPTION
This PR corrects the `build_catalog_url` method to use the proper MFEs structure
