### PR TITLE
Crls/feat/add readme and adrs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: Integration Tests in Tutor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  run-tests:
+    name: "Tests (Tutor ${{ matrix.tutor_version }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tutor_version:
+          - "==19.0.0"  # Open edX Sumac — update as new releases are supported
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run unit tests in Tutor
+        uses: eduNEXT/integration-test-in-tutor@main
+        with:
+          app_name: openedx-corporate
+          tutor_version: ${{ matrix.tutor_version }}
+          shell_file_to_run: scripts/run_tests.sh

--- a/README.rst
+++ b/README.rst
@@ -1,109 +1,199 @@
-partner-catalog
-############################
+openedx-corporate (partner-catalog)
+####################################
 
-A unified LMS plugin for Open edX that consolidates corporate partner needs into a scalable, maintainable solution.
+An Open edX Django plugin that gives corporate partners their own course catalog,
+learner invitation flow, and enrollment licensing — all running inside a standard
+Tutor-based Open edX installation without forking the LMS.
 
-The **partner-catalog** plugin addresses the specific requirements of corporate partners by providing a comprehensive system for managing corporate access, user management, and partner-specific features within the Open edX platform. This plugin leverages Open edX's plugin architecture to introduce new data models, APIs, and UI components tailored to corporate use cases.
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
 
+Overview
+********
 
-**Key Features:**
+Corporate partners need more than the standard Open edX enrollment model. They need
+to control which learners can access which courses, track who was invited and when,
+enforce seat limits, and see functional analytics across the full learner journey.
 
-* Unified partner management system
-* Corporate access control and user management
-* Scalable architecture designed for future growth
-* Easy integration with existing Open edX installations
-* Partner-specific customizations and features
+This plugin adds that layer on top of the LMS without modifying the LMS itself. It
+integrates via the Open edX plugin architecture (``lms.djangoapp`` entry point) and
+keeps all partner-specific data in its own models.
 
-Current Status
-**************
+Domain Model
+************
 
-This project is currently in early development with a modular approach to ensure:
+The domain is built around five core concepts:
 
-* Clean separation of concerns
-* Easy testing and maintenance
-* Future extensibility
-* Seamless integration with Open edX core
+**Partner**
+  A corporate organization that has contracted access to a set of courses. Backed by
+  an ``organizations.Organization`` record already present in the LMS.
 
-Getting Started with Development
-********************************
+**PartnerCatalog**
+  A time-bounded collection of courses belonging to a Partner. Controls who can access
+  it (via email regex patterns or explicit invitation), how many learners can join
+  (``user_limit``), and how many paid course seats are available (``course_enrollments_limit``).
+  A catalog is *active* only between its ``available_start_date`` and ``available_end_date``.
 
-Please see the Open edX documentation for `guidance on Python development`_ in this repo.
+**Learner invitation flow**
+  Access to a catalog is granted through an invitation:
 
-.. _guidance on Python development: https://docs.openedx.org/en/latest/developers/how-tos/get-ready-for-python-dev.html
+  1. A ``CatalogLearnerInvitation`` is created (status: ``SENT``).
+  2. The learner accepts → status becomes ``ACCEPTED``.
+  3. A ``CatalogLearner`` record is created/activated, linking the user to the catalog.
+  4. The learner can now enroll in courses inside that catalog.
 
-Deploying
-*********
+  Invitations can also be declined or removed. Status is derived from timestamps, not
+  stored as a free-form string, so it is always consistent.
 
-This plugin is designed for standard installation within a modern Open edX environment.
+**CatalogCourse**
+  The join table between a ``PartnerCatalog`` and a course (``CourseOverview`` in LMS
+  terms). Carries a ``position`` field for ordering within the catalog.
 
-**Prerequisites:**
+**CatalogCourseEnrollment**
+  A *license* that says "this user has been granted paid access to this course by this
+  catalog." One record per user+course across the entire platform — the catalog that
+  first granted the license *owns* it. See `Enrollment License Model`_ below for the
+  reasoning behind this design.
 
-* Open edX installation (**Quince** release or later recommended)
+How enrollment works
+====================
+
+When a learner requests access to a catalog course the enrollment service:
+
+1. Verifies the user is an active catalog learner and the catalog is active.
+2. Checks the current LMS enrollment mode for the user/course pair.
+3. For **paid** courses:
+
+   - If the user already has a paid LMS enrollment (e.g. ``verified``) → grant access,
+     no changes needed.
+   - If the catalog has remaining bag capacity → create or reactivate a
+     ``CatalogCourseEnrollment`` and upgrade/create the LMS enrollment to ``verified``.
+   - If the user is already in ``audit``/``honor`` and the bag is full → return a
+     warning (access is kept at the open mode, no exception raised).
+   - If there is no LMS enrollment and the bag is full → raise ``CourseLimitReached``.
+
+4. For **open** courses (audit/honor only) → enroll in ``audit``, no license record created.
+
+Deactivation works symmetrically: the license is set to inactive and the LMS enrollment
+is downgraded to ``audit``.
+
+Analytics
+=========
+
+All invitation and enrollment lifecycle events are emitted as Open edX tracking events
+and transformed to xAPI statements for the Aspects analytics pipeline. See
+`docs/decisions/0001-aspects-in-openedx-corporate.rst`_ for the full analytics ADR.
+
+.. _docs/decisions/0001-aspects-in-openedx-corporate.rst: docs/decisions/0001-aspects-in-openedx-corporate.rst
+
+Key Concepts Reference
+**********************
+
+Enrollment License Model
+========================
+
+``CatalogCourseEnrollment`` represents a *license*, not an enrollment. The LMS already
+has its own enrollment record (``CourseEnrollment``). The catalog license tracks *which
+catalog* granted paid access and whether that access is currently active.
+
+The uniqueness constraint is on ``(user, course_overview)`` — not on
+``(user, catalog_course)`` — because a user can only hold one license per course
+regardless of how many catalogs contain that course. The first catalog to grant access
+becomes the *owner*. See `docs/decisions/0002-enrollment-license-model.rst`_ for details.
+
+.. _docs/decisions/0002-enrollment-license-model.rst: docs/decisions/0002-enrollment-license-model.rst
+
+Bag Quota (``course_enrollments_limit``)
+========================================
+
+A catalog's ``course_enrollments_limit`` field sets the maximum number of active paid
+licenses owned by that catalog. Zero means unlimited. The quota is checked before
+creating or reactivating a license. It counts *distinct active paid-course enrollments*
+owned by the catalog, not total learners.
+
+User Quota (``user_limit``)
+============================
+
+``user_limit`` caps the number of active ``CatalogLearner`` records. Zero means
+unlimited. Checked before accepting an invitation.
+
+Self-enrollment catalogs
+========================
+
+When ``PartnerCatalog.is_self_enrollment`` is ``True``, any authenticated user can
+access the catalog without an invitation. Email regex patterns and learner limits still
+apply.
+
+Getting Started
+***************
+
+Requirements
+============
+
+* Open edX **Sumac** (Tutor 19) or later
 * Python **3.11**
-* Django **4.2+**
+* Django **4.2** or **5.2**
 
-**Basic Installation (Development):**
+Development installation
+========================
 
 .. code-block:: bash
 
-    # Clone the repository
     git clone <repository-url>
+    cd openedx-corporate
+    pip install -e ".[dev]"
+    python manage.py migrate --settings=test_settings
 
-    # Install in development mode
-    pip install -e .
-
-    # Run migrations
-    python manage.py migrate
-
-.. note::
-   Detailed production deployment instructions will be added as the plugin reaches maturity.
-
-Getting Help
-************
-
-Documentation
+Running tests
 =============
 
-Documentation is currently being developed alongside the plugin. For now, please refer to the source code and inline documentation.
+.. code-block:: bash
 
-As the project evolves, comprehensive documentation will be available at the standard Open edX documentation site.
+    # Unit + integration tests (SQLite, no LMS needed)
+    pytest --ds=test_settings tests/ -v
 
-More Help
-=========
+    # Full pipeline (requires Tutor)
+    bash scripts/run_tests.sh
 
-If you're having trouble, we have discussion forums at
-https://discuss.openedx.org where you can connect with others in the
-community.
+    # Quality checks
+    tox -e quality
 
-Our real-time conversations are on Slack. You can request a `Slack
-invitation`_, then join our `community Slack workspace`_.
+Project Layout
+==============
 
-For anything non-trivial, the best path is to open an issue in this
-repository with as many details about the issue you are facing as you
-can provide.
+.. code-block:: text
 
-For more information about these options, see the `Getting Help <https://openedx.org/getting-help>`__ page.
+    partner_catalog/
+    ├── models.py               # All domain models
+    ├── exceptions.py           # Domain exceptions (CourseLimitReached, etc.)
+    ├── policies/
+    │   ├── catalogs.py         # Access control (can_access_catalog, email regex)
+    │   ├── enrollments.py      # Enrollment eligibility checks
+    │   └── limits.py           # Quota checks (user_limit, course_enrollments_limit)
+    ├── services/
+    │   ├── enrollments.py      # CatalogCourseEnrollmentService
+    │   ├── invitations.py      # CatalogLearnerInvitationService
+    │   └── platform_enrollment.py  # LMS enrollment sync helpers
+    └── xapi/
+        ├── constants.py        # Event name constants
+        ├── emitter.py          # Tracking event emission
+        └── transformers.py     # xAPI statement builders
 
-.. _Slack invitation: https://openedx.org/slack
-.. _community Slack workspace: https://openedx.slack.com/
+    tests/
+    ├── factories.py            # Test data helpers
+    ├── test_catalog_course_enrollment_service.py   # No-DB unit tests
+    ├── test_invitation_service.py
+    ├── test_catalog_access_policies.py
+    └── ...                     # DB-backed integration tests
+
+Architecture Decisions
+**********************
+
+* `ADR 0001 — xAPI-Only Functional Analytics <docs/decisions/0001-aspects-in-openedx-corporate.rst>`_
+* `ADR 0002 — Enrollment License Model <docs/decisions/0002-enrollment-license-model.rst>`_
 
 License
 *******
 
-The code in this repository is licensed under the AGPL 3.0 unless
-otherwise noted.
-
-Please see `LICENSE.txt <LICENSE.txt>`_ for details.
-
-Contributing
-************
-
-Please read `How To Contribute <https://openedx.org/r/how-to-contribute>`_ for details on the Open edX contribution process.
-
-**Getting Involved:**
-1. Check the current issues and milestones
-2. Discuss new feature ideas with the maintainers before beginning development
-3. Follow Open edX coding standards and best practices
-4. Ensure comprehensive test coverage for new features
-
-You can start a conversation by creating a new issue on this repo summarizing your idea or reaching out to the team directly.
+AGPL 3.0. See `LICENSE.txt <LICENSE.txt>`_ for details.

--- a/docs/decisions/0002-enrollment-license-model.rst
+++ b/docs/decisions/0002-enrollment-license-model.rst
@@ -1,0 +1,107 @@
+ADR 0002: Catalog Course Enrollment as a Single Cross-Catalog License
+======================================================================
+
+Status
+------
+
+Accepted
+
+Date
+----
+
+2026-03-18
+
+Context
+-------
+
+A corporate learner can belong to more than one ``PartnerCatalog``, and multiple
+catalogs can contain the same course. When a learner requests access to a course that
+appears in two or more of their catalogs, the system must decide:
+
+1. How many enrollment records to create.
+2. Which catalog "owns" the learner's paid seat for quota-accounting purposes.
+3. What happens to LMS enrollment mode when access is revoked by one catalog but the
+   learner still belongs to another that contains the same course.
+
+The naive approach — one enrollment record per (user, catalog, course) — creates
+overlapping ownership, double-counting in quota checks, and ambiguity about which
+record controls the LMS enrollment mode.
+
+Decision
+--------
+
+``CatalogCourseEnrollment`` is a **license**: one record per ``(user, course)``
+across the entire platform, enforced by a ``UniqueConstraint`` on
+``(user, course_overview)``.
+
+The ``catalog_course`` foreign key on that record points to the **first catalog** that
+granted the license — the *owner*. Subsequent catalogs that contain the same course
+cannot create a second license for the same user; they simply observe that the license
+already exists.
+
+The ``course_overview`` field is denormalized from ``catalog_course.course_overview``
+to enforce the uniqueness constraint at the database level without a composite key
+spanning three tables.
+
+Quota accounting
+~~~~~~~~~~~~~~~~
+
+``course_enrollments_limit`` (the paid-seat bag) counts active licenses *owned by* a
+given catalog — i.e. records where ``catalog_course__catalog_id`` matches the catalog
+being checked. A license owned by another catalog does not consume this catalog's quota,
+even if the course appears in both catalogs.
+
+LMS enrollment mode
+~~~~~~~~~~~~~~~~~~~
+
+The LMS ``CourseEnrollment`` record is managed separately and treated as a projection
+of the catalog license state:
+
+* License active → LMS enrollment upgraded to ``verified`` (or the configured paid mode).
+* License deactivated → LMS enrollment downgraded to ``audit``.
+
+The service layer (``CatalogCourseEnrollmentService``) is the single point responsible
+for keeping both in sync. The LMS record is never created or modified directly by
+models or signals.
+
+Considered Alternatives
+-----------------------
+
+**One record per (user, catalog_course)**
+
+Rejected. A user in two catalogs that share a course would have two active records for
+the same LMS enrollment. The quota check would need to de-duplicate across catalogs to
+avoid double-counting, and deactivating one catalog's record would need to check whether
+another catalog still grants access before downgrading the LMS mode. The cross-catalog
+reconciliation logic would be both complex and error-prone.
+
+**One record per (user, catalog) with a course list**
+
+Rejected. Breaks the relational model, makes per-course operations (activate/deactivate
+a single course) more expensive, and complicates uniqueness enforcement at the DB level.
+
+Consequences
+------------
+
+Positive:
+
+* A single database row answers "does this user have a paid license for this course?"
+  without joining across catalogs.
+* Quota accounting is a simple filtered count on ``CatalogCourseEnrollment`` with no
+  deduplication step.
+* Deactivating a catalog's licenses (e.g. when a learner is removed) only touches
+  records owned by that catalog and does not affect licenses granted by other catalogs.
+* The ``UniqueConstraint`` prevents duplicate licenses at the database level, eliminating
+  a class of race-condition bugs.
+
+Negative:
+
+* The "first catalog wins" ownership rule is implicit. A learner who is later added to a
+  second catalog that contains the same course will not generate a new license record,
+  which can be surprising if operators expect per-catalog reporting.
+* When a license is deactivated, the system does not automatically check whether another
+  active catalog would re-grant access. This is intentional (deactivation is an explicit
+  operator action) but operators should be aware of the behaviour.
+* The denormalized ``course_overview`` field must be kept in sync with
+  ``catalog_course.course_overview``. This is handled in ``CatalogCourseEnrollment.save()``
+  but must be accounted for in any future migration that moves courses between catalogs.

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -11,7 +11,7 @@ echo "Running unit tests for openedx-corporate (partner_catalog)..."
 
 tutor local exec lms bash -c "
   set -euo pipefail
-  pip install pytest pytest-django pytest-cov --quiet
+  pip install pytest pytest-django pytest-cov pytest-mock --quiet
   cd /openedx/openedx-corporate
   pytest --ds=test_settings tests/ -v
 "

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# In CI the action runs this script from inside the plugin directory.
+# Tutor lives in the parent workspace's .tutor_venv — bring it into PATH.
+if [ -f ../.tutor_venv/bin/activate ]; then
+  source ../.tutor_venv/bin/activate
+fi
+
+echo "Running unit tests for openedx-corporate (partner_catalog)..."
+
+tutor local exec lms bash -c "
+  set -euo pipefail
+  pip install pytest pytest-django pytest-cov --quiet
+  cd /openedx/openedx-corporate
+  pytest --ds=test_settings tests/ -v
+"

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,7 @@ skip=
 
 [wheel]
 universal = 1
+
+[tool:pytest]
+DJANGO_SETTINGS_MODULE = test_settings
+addopts = --no-migrations

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,87 @@
+"""
+Simple factory helpers for creating test model instances.
+"""
+
+import uuid
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from organizations.models import Organization
+
+from partner_catalog.models import (
+    CatalogLearner,
+    CatalogLearnerInvitation,
+    Partner,
+    PartnerCatalog,
+)
+
+User = get_user_model()
+
+_counter = 0
+
+
+def _unique_id():
+    global _counter
+    _counter += 1
+    return _counter
+
+
+def make_user(username=None, email=None, is_staff=False, is_superuser=False):
+    username = username or f"user_{_unique_id()}"
+    email = email or f"{username}@example.com"
+    return User.objects.create_user(
+        username=username,
+        email=email,
+        password="password",
+        is_staff=is_staff,
+        is_superuser=is_superuser,
+    )
+
+
+def make_organization(short_name=None):
+    short_name = short_name or f"org_{_unique_id()}"
+    return Organization.objects.create(
+        name=f"Organization {short_name}",
+        short_name=short_name,
+    )
+
+
+def make_partner(organization=None):
+    organization = organization or make_organization()
+    return Partner.objects.create(organization=organization)
+
+
+def make_catalog(partner=None, slug=None, **kwargs):
+    partner = partner or make_partner()
+    now = timezone.now()
+    defaults = {
+        "name": f"Catalog {_unique_id()}",
+        "available_start_date": now - timedelta(days=1),
+        "available_end_date": now + timedelta(days=30),
+    }
+    defaults.update(kwargs)
+    catalog = PartnerCatalog(partner=partner, **defaults)
+    if slug:
+        catalog.slug = slug
+    catalog.save()
+    return catalog
+
+
+def make_invitation(catalog, invite_email=None, user=None, invited_by=None, **kwargs):
+    invite_email = invite_email or f"learner_{_unique_id()}@example.com"
+    return CatalogLearnerInvitation.objects.create(
+        catalog=catalog,
+        invite_email=invite_email,
+        user=user,
+        invited_by=invited_by,
+        **kwargs,
+    )
+
+
+def make_learner(catalog, user, invitation):
+    return CatalogLearner.objects.create(
+        catalog=catalog,
+        user=user,
+        current_invitation=invitation,
+    )

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -8,12 +8,7 @@ from django.contrib.auth import get_user_model
 from django.utils import timezone
 from organizations.models import Organization
 
-from partner_catalog.models import (
-    CatalogLearner,
-    CatalogLearnerInvitation,
-    Partner,
-    PartnerCatalog,
-)
+from partner_catalog.models import CatalogLearner, CatalogLearnerInvitation, Partner, PartnerCatalog
 
 User = get_user_model()
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -2,7 +2,6 @@
 Simple factory helpers for creating test model instances.
 """
 
-import uuid
 from datetime import timedelta
 
 from django.contrib.auth import get_user_model
@@ -28,6 +27,7 @@ def _unique_id():
 
 
 def make_user(username=None, email=None, is_staff=False, is_superuser=False):
+    """Create and return a User instance with a unique username."""
     username = username or f"user_{_unique_id()}"
     email = email or f"{username}@example.com"
     return User.objects.create_user(
@@ -40,6 +40,7 @@ def make_user(username=None, email=None, is_staff=False, is_superuser=False):
 
 
 def make_organization(short_name=None):
+    """Create and return an Organization with a unique short_name."""
     short_name = short_name or f"org_{_unique_id()}"
     return Organization.objects.create(
         name=f"Organization {short_name}",
@@ -48,11 +49,13 @@ def make_organization(short_name=None):
 
 
 def make_partner(organization=None):
+    """Create and return a Partner, creating an Organization if none is provided."""
     organization = organization or make_organization()
     return Partner.objects.create(organization=organization)
 
 
 def make_catalog(partner=None, slug=None, **kwargs):
+    """Create and return a PartnerCatalog with sensible date defaults."""
     partner = partner or make_partner()
     now = timezone.now()
     defaults = {
@@ -69,6 +72,7 @@ def make_catalog(partner=None, slug=None, **kwargs):
 
 
 def make_invitation(catalog, invite_email=None, user=None, invited_by=None, **kwargs):
+    """Create and return a CatalogLearnerInvitation for the given catalog."""
     invite_email = invite_email or f"learner_{_unique_id()}@example.com"
     return CatalogLearnerInvitation.objects.create(
         catalog=catalog,
@@ -80,6 +84,7 @@ def make_invitation(catalog, invite_email=None, user=None, invited_by=None, **kw
 
 
 def make_learner(catalog, user, invitation):
+    """Create and return a CatalogLearner linked to the given catalog, user, and invitation."""
     return CatalogLearner.objects.create(
         catalog=catalog,
         user=user,

--- a/tests/test_base_catalog.py
+++ b/tests/test_base_catalog.py
@@ -1,0 +1,43 @@
+"""
+Tests for BaseCatalog Singleton (Suite 9).
+
+Covers BaseCatalog.get_instance() in partner_catalog/models.py:
+- Returns the existing instance when one already exists
+- Creates the instance when none exists
+- Multiple calls return the same object (no duplicates)
+"""
+
+import pytest
+
+from partner_catalog.models import BaseCatalog
+
+
+@pytest.mark.django_db
+def test_get_instance_creates_when_none_exists():
+    """get_instance() creates a BaseCatalog when the table is empty."""
+    assert BaseCatalog.objects.count() == 0
+
+    instance = BaseCatalog.get_instance()
+
+    assert instance is not None
+    assert BaseCatalog.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_get_instance_returns_existing_instance():
+    """get_instance() returns the existing BaseCatalog without creating a duplicate."""
+    first = BaseCatalog.get_instance()
+
+    second = BaseCatalog.get_instance()
+
+    assert second.pk == first.pk
+    assert BaseCatalog.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_get_instance_multiple_calls_return_same_object():
+    """Calling get_instance() three times always yields the same record."""
+    pks = {BaseCatalog.get_instance().pk for _ in range(3)}
+
+    assert len(pks) == 1
+    assert BaseCatalog.objects.count() == 1

--- a/tests/test_catalog_access_policies.py
+++ b/tests/test_catalog_access_policies.py
@@ -1,0 +1,153 @@
+"""
+Tests for Catalog Access Policies (Suite 3).
+
+Covers `can_access_catalog()` in partner_catalog/policies/catalogs.py.
+
+Access rules implemented in the source:
+  1. Staff or superuser → always True
+  2. is_self_enrollment catalog → True for any user (no email check needed)
+  3. Active CatalogLearner → True
+  4. Email matches a catalog email regex → True (only for authenticated, non-self-enrollment)
+  5. All other cases → False
+"""
+
+import pytest
+from django.utils import timezone
+
+from partner_catalog.helpers.regex_cache import clear_email_regex_cache
+from partner_catalog.models import CatalogEmailRegex
+from partner_catalog.policies.catalogs import can_access_catalog
+
+from tests.factories import make_catalog, make_invitation, make_learner, make_user
+
+
+@pytest.fixture(autouse=True)
+def _clear_regex_cache():
+    """
+    Clear the thread-level email regex LRU cache before and after every test
+    so that regex patterns created in one test do not bleed into another.
+    """
+    clear_email_regex_cache()
+    yield
+    clear_email_regex_cache()
+
+
+# ---------------------------------------------------------------------------
+# Staff / superuser — unconditional access
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_staff_can_access_any_catalog():
+    """Staff user bypasses all other checks and always has access."""
+    staff = make_user(is_staff=True)
+    catalog = make_catalog()
+
+    assert can_access_catalog(user=staff, catalog=catalog) is True
+
+
+@pytest.mark.django_db
+def test_superuser_can_access_any_catalog():
+    """Superuser bypasses all other checks and always has access."""
+    superuser = make_user(is_superuser=True)
+    catalog = make_catalog()
+
+    assert can_access_catalog(user=superuser, catalog=catalog) is True
+
+
+# ---------------------------------------------------------------------------
+# CatalogLearner.active flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_active_learner_can_access_catalog():
+    """Active CatalogLearner (active=True) is granted access."""
+    user = make_user()
+    catalog = make_catalog()
+    invitation = make_invitation(catalog, user=user, invite_email=user.email, accepted_at=timezone.now())
+    make_learner(catalog, user, invitation)  # active=True — invitation is ACCEPTED
+
+    assert can_access_catalog(user=user, catalog=catalog) is True
+
+
+@pytest.mark.django_db
+def test_inactive_learner_without_email_match_cannot_access():
+    """Inactive CatalogLearner (active=False) with no email regex match is denied access."""
+    user = make_user()
+    catalog = make_catalog()
+    # REMOVED invitation → learner.active=False (DB constraint requires accepted_at when removed_at is set)
+    invitation = make_invitation(
+        catalog,
+        user=user,
+        invite_email=user.email,
+        accepted_at=timezone.now(),
+        removed_at=timezone.now(),
+    )
+    make_learner(catalog, user, invitation)
+    # No email regex patterns on this catalog → email_matches_catalog returns False
+
+    assert can_access_catalog(user=user, catalog=catalog) is False
+
+
+# ---------------------------------------------------------------------------
+# Self-enrollment catalog
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_self_enrollment_catalog_grants_access_to_any_authenticated_user():
+    """
+    A catalog with is_self_enrollment=True is accessible to any user.
+    The code returns True immediately on the is_self_enrollment flag,
+    without consulting learner records or email regex patterns.
+    """
+    user = make_user()
+    catalog = make_catalog(is_self_enrollment=True)
+    # No learner record, no email regex — should still be True
+
+    assert can_access_catalog(user=user, catalog=catalog) is True
+
+
+# ---------------------------------------------------------------------------
+# Email regex matching (non-self-enrollment catalog)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_email_matching_regex_grants_access():
+    """
+    Authenticated user whose email matches a catalog email regex can access
+    a non-self-enrollment catalog (even without a learner record).
+    """
+    user = make_user(email="alice@company.com")
+    catalog = make_catalog(is_self_enrollment=False)
+    CatalogEmailRegex.objects.create(catalog=catalog, regex=r".*@company\.com")
+
+    assert can_access_catalog(user=user, catalog=catalog) is True
+
+
+@pytest.mark.django_db
+def test_email_not_matching_regex_denies_access():
+    """
+    Authenticated user whose email does not match any catalog email regex
+    is denied access to a non-self-enrollment catalog.
+    """
+    user = make_user(email="alice@other.com")
+    catalog = make_catalog(is_self_enrollment=False)
+    CatalogEmailRegex.objects.create(catalog=catalog, regex=r".*@company\.com")
+
+    assert can_access_catalog(user=user, catalog=catalog) is False
+
+
+@pytest.mark.django_db
+def test_catalog_with_no_regex_patterns_denies_unenrolled_user():
+    """
+    Authenticated user with no learner record and no email regex patterns
+    defined for the catalog is denied access.
+    """
+    user = make_user()
+    catalog = make_catalog(is_self_enrollment=False)
+    # No CatalogEmailRegex rows for this catalog
+
+    assert can_access_catalog(user=user, catalog=catalog) is False

--- a/tests/test_catalog_access_policies.py
+++ b/tests/test_catalog_access_policies.py
@@ -17,7 +17,6 @@ from django.utils import timezone
 from partner_catalog.helpers.regex_cache import clear_email_regex_cache
 from partner_catalog.models import CatalogEmailRegex
 from partner_catalog.policies.catalogs import can_access_catalog
-
 from tests.factories import make_catalog, make_invitation, make_learner, make_user
 
 

--- a/tests/test_catalog_course_service.py
+++ b/tests/test_catalog_course_service.py
@@ -1,0 +1,180 @@
+"""
+Tests for CatalogCourseService - Catalog Course Positioning (Suite 7).
+
+Covers:
+- add_catalog_courses: adds a course at a specified position
+- add_catalog_courses: shifts existing courses when inserting at an occupied position
+- add_catalog_courses: appends at the end when no position is specified
+- remove_catalog_courses: removes courses and reorganizes remaining positions
+- update_course_position: reorders a course and adjusts sibling positions
+
+Note: can_course_be_added_to_catalog is mocked in all add tests to isolate
+the service's positioning logic from the catalog policy layer.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from partner_catalog.models import CatalogCourse
+from partner_catalog.services.catalog_courses import CatalogCourseService, CourseOverview
+
+from tests.factories import make_catalog
+
+PATCH_POLICY = "partner_catalog.services.catalog_courses.can_course_be_added_to_catalog"
+
+
+def make_course():
+    """Create a CourseOverviewTestModel instance."""
+    return CourseOverview.objects.create()
+
+
+def make_catalog_course(catalog, course, position):
+    """Create a CatalogCourse at the given position."""
+    return CatalogCourse.objects.create(
+        catalog=catalog,
+        course_overview=course,
+        position=position,
+    )
+
+
+# ---------------------------------------------------------------------------
+# add_catalog_courses — position insertion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_add_course_at_specified_position():
+    """add_catalog_courses creates a CatalogCourse at the given position."""
+    catalog = make_catalog()
+    course = make_course()
+
+    with patch(PATCH_POLICY, return_value=True):
+        created = CatalogCourseService.add_catalog_courses(catalog, [course.id], position=0)
+
+    assert len(created) == 1
+    assert created[0].position == 0
+    assert created[0].catalog == catalog
+    assert created[0].course_overview == course
+
+
+@pytest.mark.django_db
+def test_add_course_shifts_existing_courses():
+    """add_catalog_courses shifts courses at or after the insertion point up by one."""
+    catalog = make_catalog()
+    c0, c1, c_new = make_course(), make_course(), make_course()
+
+    cc0 = make_catalog_course(catalog, c0, position=0)
+    cc1 = make_catalog_course(catalog, c1, position=1)
+
+    with patch(PATCH_POLICY, return_value=True):
+        CatalogCourseService.add_catalog_courses(catalog, [c_new.id], position=0)
+
+    cc0.refresh_from_db()
+    cc1.refresh_from_db()
+    inserted = CatalogCourse.objects.get(catalog=catalog, course_overview=c_new)
+
+    assert inserted.position == 0
+    assert cc0.position == 1
+    assert cc1.position == 2
+
+
+@pytest.mark.django_db
+def test_add_course_appends_at_end_when_no_position_given():
+    """add_catalog_courses appends at the end when position=None."""
+    catalog = make_catalog()
+    c0, c1 = make_course(), make_course()
+
+    make_catalog_course(catalog, c0, position=0)
+
+    with patch(PATCH_POLICY, return_value=True):
+        created = CatalogCourseService.add_catalog_courses(catalog, [c1.id], position=None)
+
+    assert created[0].position == 1
+
+
+# ---------------------------------------------------------------------------
+# remove_catalog_courses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_remove_catalog_course_deletes_it():
+    """remove_catalog_courses deletes the specified CatalogCourse."""
+    catalog = make_catalog()
+    c0, c1 = make_course(), make_course()
+
+    cc0 = make_catalog_course(catalog, c0, position=0)
+    cc1 = make_catalog_course(catalog, c1, position=1)
+
+    deleted = CatalogCourseService.remove_catalog_courses(catalog, [cc1.id])
+
+    assert deleted == 1
+    assert not CatalogCourse.objects.filter(id=cc1.id).exists()
+
+
+@pytest.mark.django_db
+def test_remove_catalog_course_reorganizes_positions():
+    """remove_catalog_courses fills the gap left by the deleted course."""
+    catalog = make_catalog()
+    c0, c1, c2 = make_course(), make_course(), make_course()
+
+    cc0 = make_catalog_course(catalog, c0, position=0)
+    cc1 = make_catalog_course(catalog, c1, position=1)
+    cc2 = make_catalog_course(catalog, c2, position=2)
+
+    CatalogCourseService.remove_catalog_courses(catalog, [cc1.id])
+
+    cc0.refresh_from_db()
+    cc2.refresh_from_db()
+
+    assert cc0.position == 0
+    assert cc2.position == 1
+
+
+# ---------------------------------------------------------------------------
+# update_course_position
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_update_course_position_moves_forward():
+    """Moving a course to a higher index shifts intermediate courses down by one."""
+    catalog = make_catalog()
+    c0, c1, c2 = make_course(), make_course(), make_course()
+
+    cc0 = make_catalog_course(catalog, c0, position=0)
+    cc1 = make_catalog_course(catalog, c1, position=1)
+    cc2 = make_catalog_course(catalog, c2, position=2)
+
+    # Move cc0 from position 0 → 2
+    CatalogCourseService.update_course_position(cc0, new_position=2)
+
+    cc0.refresh_from_db()
+    cc1.refresh_from_db()
+    cc2.refresh_from_db()
+
+    assert cc0.position == 2
+    assert cc1.position == 0
+    assert cc2.position == 1
+
+
+@pytest.mark.django_db
+def test_update_course_position_moves_backward():
+    """Moving a course to a lower index shifts intermediate courses up by one."""
+    catalog = make_catalog()
+    c0, c1, c2 = make_course(), make_course(), make_course()
+
+    cc0 = make_catalog_course(catalog, c0, position=0)
+    cc1 = make_catalog_course(catalog, c1, position=1)
+    cc2 = make_catalog_course(catalog, c2, position=2)
+
+    # Move cc2 from position 2 → 0
+    CatalogCourseService.update_course_position(cc2, new_position=0)
+
+    cc0.refresh_from_db()
+    cc1.refresh_from_db()
+    cc2.refresh_from_db()
+
+    assert cc2.position == 0
+    assert cc0.position == 1
+    assert cc1.position == 2

--- a/tests/test_catalog_course_service.py
+++ b/tests/test_catalog_course_service.py
@@ -18,7 +18,6 @@ import pytest
 
 from partner_catalog.models import CatalogCourse
 from partner_catalog.services.catalog_courses import CatalogCourseService, CourseOverview
-
 from tests.factories import make_catalog
 
 PATCH_POLICY = "partner_catalog.services.catalog_courses.can_course_be_added_to_catalog"

--- a/tests/test_catalog_course_service.py
+++ b/tests/test_catalog_course_service.py
@@ -12,8 +12,9 @@ Note: can_course_be_added_to_catalog is mocked in all add tests to isolate
 the service's positioning logic from the catalog policy layer.
 """
 
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 from partner_catalog.models import CatalogCourse
 from partner_catalog.services.catalog_courses import CatalogCourseService, CourseOverview
@@ -103,7 +104,7 @@ def test_remove_catalog_course_deletes_it():
     catalog = make_catalog()
     c0, c1 = make_course(), make_course()
 
-    cc0 = make_catalog_course(catalog, c0, position=0)
+    make_catalog_course(catalog, c0, position=0)
     cc1 = make_catalog_course(catalog, c1, position=1)
 
     deleted = CatalogCourseService.remove_catalog_courses(catalog, [cc1.id])

--- a/tests/test_catalog_learner.py
+++ b/tests/test_catalog_learner.py
@@ -14,7 +14,6 @@ from django.utils import timezone
 
 from partner_catalog.models import CatalogLearnerInvitation
 from partner_catalog.services.catalogs import PartnerCatalogService
-
 from tests.factories import make_catalog, make_invitation, make_learner, make_user
 
 Status = CatalogLearnerInvitation.Status

--- a/tests/test_catalog_learner.py
+++ b/tests/test_catalog_learner.py
@@ -1,0 +1,166 @@
+"""
+Tests for CatalogLearner Activation (Suite 2).
+
+Covers:
+- CatalogLearner.active computed field based on current_invitation.status
+- PartnerCatalogService.create_or_update_learner_from_invitation
+- PartnerCatalogService.deactivate_learner_from_invitation
+"""
+
+import pytest
+from django.utils import timezone
+
+from partner_catalog.models import CatalogLearner, CatalogLearnerInvitation
+from partner_catalog.services.catalogs import PartnerCatalogService
+
+from tests.factories import make_catalog, make_invitation, make_learner, make_user
+
+Status = CatalogLearnerInvitation.Status
+
+
+@pytest.fixture
+def service():
+    return PartnerCatalogService()
+
+
+@pytest.fixture
+def user():
+    return make_user()
+
+
+@pytest.fixture
+def catalog():
+    return make_catalog()
+
+
+# ---------------------------------------------------------------------------
+# CatalogLearner.active — derived from current_invitation.status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_learner_active_when_invitation_is_accepted(user, catalog):
+    """CatalogLearner.active is True when current_invitation status is ACCEPTED."""
+    invitation = make_invitation(catalog, user=user, invite_email=user.email, accepted_at=timezone.now())
+
+    learner = make_learner(catalog, user, invitation)
+
+    assert learner.active is True
+
+
+@pytest.mark.django_db
+def test_learner_inactive_when_invitation_is_sent(user, catalog):
+    """CatalogLearner.active is False when current_invitation status is SENT (not yet accepted)."""
+    invitation = make_invitation(catalog, user=user, invite_email=user.email)
+    # No timestamps set → status == SENT
+
+    learner = make_learner(catalog, user, invitation)
+
+    assert learner.active is False
+
+
+@pytest.mark.django_db
+def test_learner_inactive_when_invitation_is_removed(user, catalog):
+    """CatalogLearner.active is False when current_invitation status is REMOVED."""
+    # DB constraint cla_removed_implies_accepted requires accepted_at when removed_at is set
+    invitation = make_invitation(
+        catalog,
+        user=user,
+        invite_email=user.email,
+        accepted_at=timezone.now(),
+        removed_at=timezone.now(),
+    )
+    # _compute_status: removed_at is set → status == REMOVED
+
+    learner = make_learner(catalog, user, invitation)
+
+    assert learner.active is False
+
+
+@pytest.mark.django_db
+def test_learner_inactive_when_invitation_is_declined(user, catalog):
+    """CatalogLearner.active is False when current_invitation status is DECLINED."""
+    invitation = make_invitation(
+        catalog,
+        user=user,
+        invite_email=user.email,
+        declined_at=timezone.now(),
+    )
+    # _compute_status: declined_at is set → status == DECLINED
+
+    learner = make_learner(catalog, user, invitation)
+
+    assert learner.active is False
+
+
+# ---------------------------------------------------------------------------
+# PartnerCatalogService.create_or_update_learner_from_invitation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_or_update_creates_new_learner(service, user, catalog):
+    """create_or_update_learner_from_invitation creates a new CatalogLearner when none exists."""
+    invitation = make_invitation(catalog, user=user, invite_email=user.email, accepted_at=timezone.now())
+
+    learner, created = service.create_or_update_learner_from_invitation(invitation.id)
+
+    assert created is True
+    assert learner.user == user
+    assert learner.catalog == catalog
+    assert learner.active is True
+
+
+@pytest.mark.django_db
+def test_create_or_update_reactivates_existing_inactive_learner(service, user, catalog):
+    """create_or_update_learner_from_invitation reactivates an existing inactive CatalogLearner."""
+    # Step 1: create learner via an ACCEPTED invitation
+    invitation_1 = make_invitation(catalog, user=user, invite_email=user.email, accepted_at=timezone.now())
+    learner = make_learner(catalog, user, invitation_1)
+    # Link invitation_1 to the learner for history tracking (as the service does)
+    invitation_1.learner = learner
+    invitation_1.save(update_fields=['learner'])
+    assert learner.active is True
+
+    # Step 2: transition invitation_1 to REMOVED → learner becomes inactive
+    invitation_1.removed_at = timezone.now()
+    invitation_1.save()
+    learner.save()
+    learner.refresh_from_db()
+    assert learner.active is False
+
+    # Step 3: create a fresh ACCEPTED invitation for the same user+catalog
+    # (invitation_1 is REMOVED/status=40, outside the unique-active constraint on [10, 20])
+    invitation_2 = make_invitation(catalog, user=user, invite_email=user.email, accepted_at=timezone.now())
+
+    updated_learner, created = service.create_or_update_learner_from_invitation(invitation_2.id)
+
+    assert created is False                    # existing record was found
+    assert updated_learner.id == learner.id    # same CatalogLearner row
+    assert updated_learner.active is True      # reactivated
+
+
+# ---------------------------------------------------------------------------
+# PartnerCatalogService.deactivate_learner_from_invitation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_deactivate_learner_sets_active_false(service, user, catalog):
+    """deactivate_learner_from_invitation sets CatalogLearner.active to False."""
+    invitation = make_invitation(catalog, user=user, invite_email=user.email, accepted_at=timezone.now())
+    learner = make_learner(catalog, user, invitation)
+    assert learner.active is True
+
+    # Link invitation → learner so the service can navigate to the learner
+    invitation.learner = learner
+    invitation.save(update_fields=['learner'])
+
+    # Transition invitation to REMOVED so _compute_active() returns False on next save
+    invitation.removed_at = timezone.now()
+    invitation.save()
+
+    deactivated = service.deactivate_learner_from_invitation(invitation.id)
+
+    deactivated.refresh_from_db()
+    assert deactivated.active is False

--- a/tests/test_catalog_learner.py
+++ b/tests/test_catalog_learner.py
@@ -7,10 +7,12 @@ Covers:
 - PartnerCatalogService.deactivate_learner_from_invitation
 """
 
+# pylint: disable=redefined-outer-name
+
 import pytest
 from django.utils import timezone
 
-from partner_catalog.models import CatalogLearner, CatalogLearnerInvitation
+from partner_catalog.models import CatalogLearnerInvitation
 from partner_catalog.services.catalogs import PartnerCatalogService
 
 from tests.factories import make_catalog, make_invitation, make_learner, make_user

--- a/tests/test_catalog_manager.py
+++ b/tests/test_catalog_manager.py
@@ -1,0 +1,89 @@
+"""
+Tests for CatalogManager Validation (Suite 8).
+
+Covers model-level constraints in partner_catalog/models.py → CatalogManager:
+- A user can be assigned as manager to a catalog from their partner's organization
+- A user cannot manage catalogs from two different partner organizations
+- Unique constraint prevents the same user from being assigned to the same catalog twice
+"""
+
+import pytest
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError
+
+from partner_catalog.models import CatalogManager
+
+from tests.factories import make_catalog, make_partner, make_user
+
+
+# ---------------------------------------------------------------------------
+# Valid assignment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_manager_can_be_assigned_to_own_partner_catalog():
+    """A user can be assigned as manager to a catalog belonging to their partner."""
+    user = make_user()
+    catalog = make_catalog()
+
+    manager = CatalogManager(catalog=catalog, user=user)
+    manager.save()  # should not raise
+
+    assert CatalogManager.objects.filter(catalog=catalog, user=user).exists()
+
+
+# ---------------------------------------------------------------------------
+# Cross-partner constraint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_manager_cannot_manage_catalogs_from_different_partners():
+    """A user already managing a catalog cannot be assigned to a catalog from a different partner."""
+    user = make_user()
+
+    partner_a_catalog = make_catalog()
+    partner_b_catalog = make_catalog()  # different partner (make_catalog creates a new one each time)
+
+    # Assign user to partner A's catalog
+    CatalogManager.objects.create(catalog=partner_a_catalog, user=user)
+
+    # Attempt to assign the same user to partner B's catalog
+    manager = CatalogManager(catalog=partner_b_catalog, user=user)
+    with pytest.raises(ValidationError, match="different partner organization"):
+        manager.save()
+
+
+@pytest.mark.django_db
+def test_manager_can_manage_multiple_catalogs_from_same_partner():
+    """A user can manage two catalogs that belong to the same partner."""
+    user = make_user()
+    partner = make_partner()
+
+    catalog_a = make_catalog(partner=partner)
+    catalog_b = make_catalog(partner=partner)
+
+    CatalogManager.objects.create(catalog=catalog_a, user=user)
+
+    manager = CatalogManager(catalog=catalog_b, user=user)
+    manager.save()  # should not raise
+
+    assert CatalogManager.objects.filter(user=user).count() == 2
+
+
+# ---------------------------------------------------------------------------
+# Unique constraint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_same_user_cannot_be_assigned_to_same_catalog_twice():
+    """UniqueConstraint prevents duplicate (catalog, user) assignments."""
+    user = make_user()
+    catalog = make_catalog()
+
+    CatalogManager.objects.create(catalog=catalog, user=user)
+
+    with pytest.raises(IntegrityError):
+        CatalogManager.objects.create(catalog=catalog, user=user)

--- a/tests/test_catalog_manager.py
+++ b/tests/test_catalog_manager.py
@@ -12,7 +12,6 @@ from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 
 from partner_catalog.models import CatalogManager
-
 from tests.factories import make_catalog, make_partner, make_user
 
 

--- a/tests/test_catalog_manager.py
+++ b/tests/test_catalog_manager.py
@@ -14,7 +14,6 @@ from django.db import IntegrityError
 from partner_catalog.models import CatalogManager
 from tests.factories import make_catalog, make_partner, make_user
 
-
 # ---------------------------------------------------------------------------
 # Valid assignment
 # ---------------------------------------------------------------------------

--- a/tests/test_email_regex.py
+++ b/tests/test_email_regex.py
@@ -1,0 +1,156 @@
+"""
+Tests for Email Regex Validation (Suite 4).
+
+Covers:
+  - `CatalogEmailRegex.clean()` — normalization and validation on save
+  - `email_matches_catalog()` — runtime email matching against stored patterns
+"""
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from partner_catalog.helpers.regex_cache import clear_email_regex_cache
+from partner_catalog.models import CatalogEmailRegex
+from partner_catalog.policies.catalogs import email_matches_catalog
+
+from tests.factories import make_catalog
+
+
+@pytest.fixture(autouse=True)
+def _clear_regex_cache():
+    """Clear the LRU regex cache before and after every test to avoid cross-test contamination."""
+    clear_email_regex_cache()
+    yield
+    clear_email_regex_cache()
+
+
+# ---------------------------------------------------------------------------
+# CatalogEmailRegex.clean() — pattern normalization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_pattern_is_normalized_to_anchored_form():
+    """
+    A bare pattern (without ^ and $) must be auto-wrapped to ^{pattern}$ on save.
+    """
+    catalog = make_catalog()
+    entry = CatalogEmailRegex.objects.create(catalog=catalog, regex=r".*@company\.com")
+
+    assert entry.regex == r"^.*@company\.com$"
+
+
+@pytest.mark.django_db
+def test_pattern_already_anchored_is_not_double_wrapped():
+    """
+    A pattern that already starts with ^ and ends with $ must not get extra anchors.
+    """
+    catalog = make_catalog()
+    entry = CatalogEmailRegex.objects.create(catalog=catalog, regex=r"^.*@company\.com$")
+
+    assert entry.regex == r"^.*@company\.com$"
+
+
+@pytest.mark.django_db
+def test_valid_pattern_saves_without_error():
+    """A syntactically valid regex pattern must save successfully."""
+    catalog = make_catalog()
+    # Should not raise
+    entry = CatalogEmailRegex.objects.create(catalog=catalog, regex=r"[a-z]+@example\.com")
+
+    assert entry.pk is not None
+
+
+@pytest.mark.django_db
+def test_nested_quantifiers_raise_validation_error():
+    """
+    A pattern with nested quantifiers (e.g. (a+)+) must raise ValidationError.
+    The check in clean() detects (.*)+ / (.+)+ style patterns.
+    """
+    catalog = make_catalog()
+    instance = CatalogEmailRegex(catalog=catalog, regex=r"(.*)+@company\.com")
+
+    with pytest.raises(ValidationError, match="nested quantifiers"):
+        instance.clean()
+
+
+@pytest.mark.django_db
+def test_multiple_consecutive_wildcards_raise_validation_error():
+    """
+    A pattern with multiple consecutive .* wildcards (e.g. .*.*) must raise ValidationError.
+    """
+    catalog = make_catalog()
+    instance = CatalogEmailRegex(catalog=catalog, regex=r".*.*@company\.com")
+
+    with pytest.raises(ValidationError, match="nested quantifiers"):
+        instance.clean()
+
+
+@pytest.mark.django_db
+def test_invalid_regex_syntax_raises_validation_error():
+    """An unparseable regex (unclosed bracket) must raise ValidationError."""
+    catalog = make_catalog()
+    instance = CatalogEmailRegex(catalog=catalog, regex=r"[unclosed")
+
+    with pytest.raises(ValidationError, match="Invalid regex"):
+        instance.clean()
+
+
+# ---------------------------------------------------------------------------
+# email_matches_catalog() — runtime matching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_email_matches_catalog_returns_true_on_match():
+    """email_matches_catalog returns True when the email matches at least one pattern."""
+    catalog = make_catalog()
+    CatalogEmailRegex.objects.create(catalog=catalog, regex=r".*@company\.com")
+
+    assert email_matches_catalog("alice@company.com", catalog.id) is True
+
+
+@pytest.mark.django_db
+def test_email_matches_catalog_returns_false_on_no_match():
+    """email_matches_catalog returns False when the email matches none of the patterns."""
+    catalog = make_catalog()
+    CatalogEmailRegex.objects.create(catalog=catalog, regex=r".*@company\.com")
+
+    assert email_matches_catalog("alice@other.org", catalog.id) is False
+
+
+@pytest.mark.django_db
+def test_email_matches_catalog_returns_false_when_no_patterns():
+    """email_matches_catalog returns False when the catalog has no patterns defined."""
+    catalog = make_catalog()
+    # No CatalogEmailRegex rows
+
+    assert email_matches_catalog("alice@company.com", catalog.id) is False
+
+
+@pytest.mark.django_db
+def test_email_matching_is_case_insensitive():
+    """Pattern matching must be case-insensitive (IGNORECASE flag in the cache)."""
+    catalog = make_catalog()
+    CatalogEmailRegex.objects.create(catalog=catalog, regex=r".*@company\.com")
+
+    assert email_matches_catalog("ALICE@COMPANY.COM", catalog.id) is True
+
+
+@pytest.mark.django_db
+def test_email_matches_first_of_multiple_patterns():
+    """email_matches_catalog returns True when the email matches the first of several patterns."""
+    catalog = make_catalog()
+    CatalogEmailRegex.objects.create(catalog=catalog, regex=r".*@company\.com")
+    CatalogEmailRegex.objects.create(catalog=catalog, regex=r".*@partner\.org")
+
+    assert email_matches_catalog("bob@partner.org", catalog.id) is True
+
+
+@pytest.mark.django_db
+def test_none_email_returns_false():
+    """email_matches_catalog returns False when email is None."""
+    catalog = make_catalog()
+    CatalogEmailRegex.objects.create(catalog=catalog, regex=r".*@company\.com")
+
+    assert email_matches_catalog(None, catalog.id) is False

--- a/tests/test_email_regex.py
+++ b/tests/test_email_regex.py
@@ -12,7 +12,6 @@ from django.core.exceptions import ValidationError
 from partner_catalog.helpers.regex_cache import clear_email_regex_cache
 from partner_catalog.models import CatalogEmailRegex
 from partner_catalog.policies.catalogs import email_matches_catalog
-
 from tests.factories import make_catalog
 
 

--- a/tests/test_enrollment_policies.py
+++ b/tests/test_enrollment_policies.py
@@ -13,7 +13,6 @@ policy function in the current code — those test plan items are N/A.
 from datetime import timedelta
 
 import pytest
-
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 
@@ -22,7 +21,6 @@ from partner_catalog.policies.catalogs import (
     is_catalog_available,
     validate_catalog_enrollment_request,
 )
-
 from tests.factories import make_catalog, make_invitation, make_learner, make_user
 
 

--- a/tests/test_enrollment_policies.py
+++ b/tests/test_enrollment_policies.py
@@ -1,0 +1,190 @@
+"""
+Tests for Catalog Enrollment Policies (Suite 6).
+
+Covers:
+- validate_catalog_enrollment_request: raises on unavailable catalog or non-ACCEPTED invitation
+- has_catalog_capacity: user_limit=0 means no limit; blocks when limit is reached
+- is_catalog_available: combines catalog.active + has_catalog_capacity
+
+Note: course_enrollments_limit is a model field but is not enforced by any
+policy function in the current code — those test plan items are N/A.
+"""
+
+import pytest
+from datetime import timedelta
+
+from django.core.exceptions import ValidationError
+from django.utils import timezone
+
+from partner_catalog.policies.catalogs import (
+    has_catalog_capacity,
+    is_catalog_available,
+    validate_catalog_enrollment_request,
+)
+
+from tests.factories import make_catalog, make_invitation, make_learner, make_user
+
+
+# ---------------------------------------------------------------------------
+# has_catalog_capacity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_catalog_has_capacity_when_user_limit_is_zero():
+    """has_catalog_capacity returns True when user_limit=0 (no limit enforced)."""
+    catalog = make_catalog(user_limit=0)
+
+    assert has_catalog_capacity(catalog=catalog) is True
+
+
+@pytest.mark.django_db
+def test_catalog_has_capacity_when_below_user_limit():
+    """has_catalog_capacity returns True when active learner count is below user_limit."""
+    catalog = make_catalog(user_limit=5)
+    # 2 active learners, limit is 5 → still capacity
+    for _ in range(2):
+        user = make_user()
+        invitation = make_invitation(catalog, user=user, invite_email=user.email, accepted_at=timezone.now())
+        make_learner(catalog, user, invitation)
+
+    assert has_catalog_capacity(catalog=catalog) is True
+
+
+@pytest.mark.django_db
+def test_catalog_at_capacity_when_user_limit_reached():
+    """has_catalog_capacity returns False when active learner count equals user_limit."""
+    catalog = make_catalog(user_limit=2)
+    for _ in range(2):
+        user = make_user()
+        invitation = make_invitation(catalog, user=user, invite_email=user.email, accepted_at=timezone.now())
+        make_learner(catalog, user, invitation)
+
+    assert has_catalog_capacity(catalog=catalog) is False
+
+
+# ---------------------------------------------------------------------------
+# is_catalog_available
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_catalog_available_when_active_and_has_capacity():
+    """is_catalog_available returns True when catalog is active and has remaining capacity."""
+    now = timezone.now()
+    catalog = make_catalog(
+        available_start_date=now - timedelta(days=1),
+        available_end_date=now + timedelta(days=1),
+        user_limit=0,
+    )
+
+    assert is_catalog_available(catalog=catalog) is True
+
+
+@pytest.mark.django_db
+def test_catalog_unavailable_when_outside_date_window():
+    """is_catalog_available returns False when catalog is not active (past end date)."""
+    now = timezone.now()
+    catalog = make_catalog(
+        available_start_date=now - timedelta(days=2),
+        available_end_date=now - timedelta(days=1),
+        user_limit=0,
+    )
+
+    assert is_catalog_available(catalog=catalog) is False
+
+
+@pytest.mark.django_db
+def test_catalog_unavailable_when_user_limit_reached():
+    """is_catalog_available returns False when the catalog has reached its user limit."""
+    now = timezone.now()
+    catalog = make_catalog(
+        available_start_date=now - timedelta(days=1),
+        available_end_date=now + timedelta(days=1),
+        user_limit=1,
+    )
+    user = make_user()
+    invitation = make_invitation(catalog, user=user, invite_email=user.email, accepted_at=timezone.now())
+    make_learner(catalog, user, invitation)
+
+    assert is_catalog_available(catalog=catalog) is False
+
+
+# ---------------------------------------------------------------------------
+# validate_catalog_enrollment_request
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_enrollment_allowed_when_catalog_available_and_invitation_accepted():
+    """validate_catalog_enrollment_request does not raise when catalog is available and invitation is ACCEPTED."""
+    now = timezone.now()
+    catalog = make_catalog(
+        available_start_date=now - timedelta(days=1),
+        available_end_date=now + timedelta(days=1),
+        user_limit=0,
+    )
+    user = make_user()
+    invitation = make_invitation(catalog, user=user, invite_email=user.email, accepted_at=timezone.now())
+
+    # Should not raise
+    validate_catalog_enrollment_request(invitation=invitation)
+
+
+@pytest.mark.django_db
+def test_enrollment_blocked_when_catalog_not_active():
+    """validate_catalog_enrollment_request raises ValidationError when catalog is outside its date window."""
+    now = timezone.now()
+    catalog = make_catalog(
+        available_start_date=now - timedelta(days=2),
+        available_end_date=now - timedelta(days=1),
+        user_limit=0,
+    )
+    user = make_user()
+    invitation = make_invitation(catalog, user=user, invite_email=user.email, accepted_at=timezone.now())
+
+    with pytest.raises(ValidationError, match="not available"):
+        validate_catalog_enrollment_request(invitation=invitation)
+
+
+@pytest.mark.django_db
+def test_enrollment_blocked_when_catalog_at_user_limit():
+    """validate_catalog_enrollment_request raises ValidationError when catalog has reached its user limit."""
+    now = timezone.now()
+    catalog = make_catalog(
+        available_start_date=now - timedelta(days=1),
+        available_end_date=now + timedelta(days=1),
+        user_limit=1,
+    )
+    # Fill the one slot
+    existing_user = make_user()
+    existing_invitation = make_invitation(
+        catalog, user=existing_user, invite_email=existing_user.email, accepted_at=timezone.now()
+    )
+    make_learner(catalog, existing_user, existing_invitation)
+
+    # A second user tries to enroll
+    new_user = make_user()
+    new_invitation = make_invitation(
+        catalog, user=new_user, invite_email=new_user.email, accepted_at=timezone.now()
+    )
+
+    with pytest.raises(ValidationError, match="not available"):
+        validate_catalog_enrollment_request(invitation=new_invitation)
+
+
+@pytest.mark.django_db
+def test_enrollment_blocked_when_invitation_not_accepted():
+    """validate_catalog_enrollment_request raises ValidationError when invitation status is not ACCEPTED."""
+    now = timezone.now()
+    catalog = make_catalog(
+        available_start_date=now - timedelta(days=1),
+        available_end_date=now + timedelta(days=1),
+        user_limit=0,
+    )
+    user = make_user()
+    # Invitation in SENT state (no accepted_at)
+    invitation = make_invitation(catalog, user=user, invite_email=user.email)
+
+    with pytest.raises(ValidationError, match="must be accepted"):
+        validate_catalog_enrollment_request(invitation=invitation)

--- a/tests/test_enrollment_policies.py
+++ b/tests/test_enrollment_policies.py
@@ -10,8 +10,9 @@ Note: course_enrollments_limit is a model field but is not enforced by any
 policy function in the current code — those test plan items are N/A.
 """
 
-import pytest
 from datetime import timedelta
+
+import pytest
 
 from django.core.exceptions import ValidationError
 from django.utils import timezone

--- a/tests/test_enrollment_policies.py
+++ b/tests/test_enrollment_policies.py
@@ -23,7 +23,6 @@ from partner_catalog.policies.catalogs import (
 )
 from tests.factories import make_catalog, make_invitation, make_learner, make_user
 
-
 # ---------------------------------------------------------------------------
 # has_catalog_capacity
 # ---------------------------------------------------------------------------

--- a/tests/test_enrollment_policies.py
+++ b/tests/test_enrollment_policies.py
@@ -16,6 +16,7 @@ import pytest
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 
+from partner_catalog.exceptions import InactiveCatalogEnrollment, UserLimitReached
 from partner_catalog.policies.catalogs import (
     has_catalog_capacity,
     is_catalog_available,
@@ -141,7 +142,7 @@ def test_enrollment_blocked_when_catalog_not_active():
     user = make_user()
     invitation = make_invitation(catalog, user=user, invite_email=user.email, accepted_at=timezone.now())
 
-    with pytest.raises(ValidationError, match="not available"):
+    with pytest.raises(InactiveCatalogEnrollment):
         validate_catalog_enrollment_request(invitation=invitation)
 
 
@@ -167,7 +168,7 @@ def test_enrollment_blocked_when_catalog_at_user_limit():
         catalog, user=new_user, invite_email=new_user.email, accepted_at=timezone.now()
     )
 
-    with pytest.raises(ValidationError, match="not available"):
+    with pytest.raises(UserLimitReached):
         validate_catalog_enrollment_request(invitation=new_invitation)
 
 

--- a/tests/test_invitation_service.py
+++ b/tests/test_invitation_service.py
@@ -5,6 +5,8 @@ Covers business logic for invitation creation, status transitions, and model-lev
 constraints (accepted/declined mutual exclusion, unique active invitation).
 """
 
+# pylint: disable=redefined-outer-name
+
 import pytest
 from django.db import IntegrityError
 from django.utils import timezone
@@ -51,7 +53,8 @@ def test_create_invitation_has_status_sent(service, catalog, learner_user):
 
 @pytest.mark.django_db
 def test_create_invitation_raises_if_sent_already_exists(service, catalog, learner_user):
-    """create_new_invitation raises ValidationError when a SENT invitation already exists for the same (catalog, email)."""
+    """create_new_invitation raises ValidationError when a SENT invitation already exists
+    for the same (catalog, email)."""
     service.create_new_invitation(
         invite_email=learner_user.email,
         catalog_id=catalog.id,
@@ -68,7 +71,8 @@ def test_create_invitation_raises_if_sent_already_exists(service, catalog, learn
 
 @pytest.mark.django_db
 def test_create_invitation_raises_if_accepted_already_exists(service, catalog, learner_user):
-    """create_new_invitation raises ValidationError when an ACCEPTED invitation already exists for the same (catalog, email)."""
+    """create_new_invitation raises ValidationError when an ACCEPTED invitation already exists
+    for the same (catalog, email)."""
     # Create and accept an invitation
     invitation = service.create_new_invitation(
         invite_email=learner_user.email,

--- a/tests/test_invitation_service.py
+++ b/tests/test_invitation_service.py
@@ -14,7 +14,6 @@ from rest_framework.exceptions import ValidationError
 
 from partner_catalog.models import CatalogLearnerInvitation
 from partner_catalog.services.invitations import CatalogLearnerInvitationService
-
 from tests.factories import make_catalog, make_invitation, make_user
 
 Status = CatalogLearnerInvitation.Status

--- a/tests/test_invitation_service.py
+++ b/tests/test_invitation_service.py
@@ -1,0 +1,307 @@
+"""
+Tests for CatalogLearnerInvitationService - Invitation Lifecycle (Suite 1).
+
+Covers business logic for invitation creation, status transitions, and model-level
+constraints (accepted/declined mutual exclusion, unique active invitation).
+"""
+
+import pytest
+from django.db import IntegrityError
+from django.utils import timezone
+from rest_framework.exceptions import ValidationError
+
+from partner_catalog.models import CatalogLearnerInvitation
+from partner_catalog.services.invitations import CatalogLearnerInvitationService
+
+from tests.factories import make_catalog, make_invitation, make_user
+
+Status = CatalogLearnerInvitation.Status
+
+
+@pytest.fixture
+def service():
+    return CatalogLearnerInvitationService()
+
+
+@pytest.fixture
+def catalog():
+    return make_catalog()
+
+
+@pytest.fixture
+def learner_user():
+    return make_user(email="learner@example.com")
+
+
+# ---------------------------------------------------------------------------
+# create_new_invitation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_create_invitation_has_status_sent(service, catalog, learner_user):
+    """create_new_invitation should return an invitation with status SENT."""
+    invitation = service.create_new_invitation(
+        invite_email=learner_user.email,
+        catalog_id=catalog.id,
+        emit_event=False,
+    )
+
+    assert invitation.status == Status.SENT
+
+
+@pytest.mark.django_db
+def test_create_invitation_raises_if_sent_already_exists(service, catalog, learner_user):
+    """create_new_invitation raises ValidationError when a SENT invitation already exists for the same (catalog, email)."""
+    service.create_new_invitation(
+        invite_email=learner_user.email,
+        catalog_id=catalog.id,
+        emit_event=False,
+    )
+
+    with pytest.raises(ValidationError, match=service.ERROR_ACTIVE_INVITATION_EXISTS):
+        service.create_new_invitation(
+            invite_email=learner_user.email,
+            catalog_id=catalog.id,
+            emit_event=False,
+        )
+
+
+@pytest.mark.django_db
+def test_create_invitation_raises_if_accepted_already_exists(service, catalog, learner_user):
+    """create_new_invitation raises ValidationError when an ACCEPTED invitation already exists for the same (catalog, email)."""
+    # Create and accept an invitation
+    invitation = service.create_new_invitation(
+        invite_email=learner_user.email,
+        catalog_id=catalog.id,
+        emit_event=False,
+    )
+    service.accept_invitation(invitation.id, user=learner_user)
+
+    with pytest.raises(ValidationError, match=service.ERROR_ACTIVE_INVITATION_EXISTS):
+        service.create_new_invitation(
+            invite_email=learner_user.email,
+            catalog_id=catalog.id,
+            emit_event=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# accept_invitation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_accept_invitation_transitions_to_accepted(service, catalog, learner_user):
+    """accept_invitation should transition the status from SENT to ACCEPTED and set accepted_at."""
+    invitation = service.create_new_invitation(
+        invite_email=learner_user.email,
+        catalog_id=catalog.id,
+        emit_event=False,
+    )
+
+    accepted = service.accept_invitation(invitation.id, user=learner_user)
+
+    assert accepted.status == Status.ACCEPTED
+    assert accepted.accepted_at is not None
+
+
+@pytest.mark.django_db
+def test_accept_invitation_raises_when_already_declined(service, catalog, learner_user):
+    """accept_invitation raises ValidationError when the invitation status is DECLINED."""
+    invitation = service.create_new_invitation(
+        invite_email=learner_user.email,
+        catalog_id=catalog.id,
+        emit_event=False,
+    )
+    service.decline_invitation(invitation.id, user=learner_user)
+
+    with pytest.raises(ValidationError, match=service.ERROR_ACCEPT_NOT_ALLOWED):
+        service.accept_invitation(invitation.id, user=learner_user)
+
+
+@pytest.mark.django_db
+def test_accept_invitation_raises_when_already_removed(service, catalog, learner_user):
+    """accept_invitation raises ValidationError when the invitation status is REMOVED."""
+    invitation = service.create_new_invitation(
+        invite_email=learner_user.email,
+        catalog_id=catalog.id,
+        emit_event=False,
+    )
+    # accept → remove
+    service.accept_invitation(invitation.id, user=learner_user)
+    service.remove_invitation(invitation.id, user=learner_user)
+
+    with pytest.raises(ValidationError, match=service.ERROR_ACCEPT_NOT_ALLOWED):
+        service.accept_invitation(invitation.id, user=learner_user)
+
+
+# ---------------------------------------------------------------------------
+# decline_invitation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_decline_invitation_transitions_to_declined(service, catalog, learner_user):
+    """decline_invitation should transition the status from SENT to DECLINED and set declined_at."""
+    invitation = service.create_new_invitation(
+        invite_email=learner_user.email,
+        catalog_id=catalog.id,
+        emit_event=False,
+    )
+
+    declined = service.decline_invitation(invitation.id, user=learner_user)
+
+    assert declined.status == Status.DECLINED
+    assert declined.declined_at is not None
+
+
+@pytest.mark.django_db
+def test_decline_invitation_raises_when_already_accepted(service, catalog, learner_user):
+    """decline_invitation raises ValidationError when the invitation status is ACCEPTED."""
+    invitation = service.create_new_invitation(
+        invite_email=learner_user.email,
+        catalog_id=catalog.id,
+        emit_event=False,
+    )
+    service.accept_invitation(invitation.id, user=learner_user)
+
+    with pytest.raises(ValidationError, match=service.ERROR_DECLINE_NOT_ALLOWED):
+        service.decline_invitation(invitation.id, user=learner_user)
+
+
+@pytest.mark.django_db
+def test_decline_invitation_raises_when_already_removed(service, catalog, learner_user):
+    """decline_invitation raises ValidationError when the invitation status is REMOVED."""
+    invitation = service.create_new_invitation(
+        invite_email=learner_user.email,
+        catalog_id=catalog.id,
+        emit_event=False,
+    )
+    service.accept_invitation(invitation.id, user=learner_user)
+    service.remove_invitation(invitation.id, user=learner_user)
+
+    with pytest.raises(ValidationError, match=service.ERROR_DECLINE_NOT_ALLOWED):
+        service.decline_invitation(invitation.id, user=learner_user)
+
+
+# ---------------------------------------------------------------------------
+# remove_invitation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_remove_invitation_transitions_to_removed(service, catalog, learner_user):
+    """remove_invitation should transition the status from ACCEPTED to REMOVED, setting removed_at and removed_by."""
+    invitation = service.create_new_invitation(
+        invite_email=learner_user.email,
+        catalog_id=catalog.id,
+        emit_event=False,
+    )
+    service.accept_invitation(invitation.id, user=learner_user)
+
+    removed = service.remove_invitation(invitation.id, user=learner_user)
+
+    assert removed.status == Status.REMOVED
+    assert removed.removed_at is not None
+    assert removed.removed_by == learner_user
+
+
+@pytest.mark.django_db
+def test_remove_invitation_allowed_by_staff(service, catalog, learner_user):
+    """remove_invitation should be allowed when a staff user performs the removal."""
+    staff = make_user(is_staff=True)
+    invitation = service.create_new_invitation(
+        invite_email=learner_user.email,
+        catalog_id=catalog.id,
+        emit_event=False,
+    )
+    service.accept_invitation(invitation.id, user=learner_user)
+
+    removed = service.remove_invitation(invitation.id, user=staff)
+
+    assert removed.status == Status.REMOVED
+
+
+@pytest.mark.django_db
+def test_remove_invitation_raises_when_sent(service, catalog, learner_user):
+    """remove_invitation raises ValidationError when the invitation has not been accepted yet (status SENT)."""
+    invitation = service.create_new_invitation(
+        invite_email=learner_user.email,
+        catalog_id=catalog.id,
+        emit_event=False,
+    )
+
+    with pytest.raises(ValidationError, match=service.ERROR_REMOVE_NOT_ALLOWED):
+        service.remove_invitation(invitation.id, user=learner_user)
+
+
+@pytest.mark.django_db
+def test_remove_invitation_raises_when_declined(service, catalog, learner_user):
+    """remove_invitation raises ValidationError when the invitation status is DECLINED."""
+    invitation = service.create_new_invitation(
+        invite_email=learner_user.email,
+        catalog_id=catalog.id,
+        emit_event=False,
+    )
+    service.decline_invitation(invitation.id, user=learner_user)
+
+    with pytest.raises(ValidationError, match=service.ERROR_REMOVE_NOT_ALLOWED):
+        service.remove_invitation(invitation.id, user=learner_user)
+
+
+# ---------------------------------------------------------------------------
+# Status derivation from timestamps (_compute_status)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_status_is_sent_when_no_timestamps(catalog):
+    """An invitation with no timestamps should have status SENT."""
+    invitation = make_invitation(catalog, invite_email="new@example.com")
+    assert invitation.status == Status.SENT
+
+
+@pytest.mark.django_db
+def test_status_is_accepted_when_accepted_at_is_set(catalog):
+    """An invitation with accepted_at set (and no other timestamps) should have status ACCEPTED."""
+    invitation = make_invitation(
+        catalog,
+        invite_email="accepted@example.com",
+        accepted_at=timezone.now(),
+    )
+    assert invitation.status == Status.ACCEPTED
+
+
+@pytest.mark.django_db
+def test_status_is_declined_when_declined_at_is_set(catalog):
+    """An invitation with declined_at set (and no accepted/removed timestamps) should have status DECLINED."""
+    invitation = make_invitation(
+        catalog,
+        invite_email="declined@example.com",
+        declined_at=timezone.now(),
+    )
+    assert invitation.status == Status.DECLINED
+
+
+@pytest.mark.django_db
+def test_status_is_removed_when_removed_at_is_set(catalog):
+    """An invitation with removed_at set should have status REMOVED (takes priority)."""
+    invitation = make_invitation(
+        catalog,
+        invite_email="removed@example.com",
+        accepted_at=timezone.now(),
+        removed_at=timezone.now(),
+    )
+    assert invitation.status == Status.REMOVED
+
+
+# ---------------------------------------------------------------------------
+# Model constraint: accepted_at and declined_at cannot both be set
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_cannot_set_both_accepted_and_declined_at(catalog):
+    """DB check constraint should prevent an invitation from having both accepted_at and declined_at set."""
+    with pytest.raises((IntegrityError, Exception)):
+        make_invitation(
+            catalog,
+            invite_email="conflict@example.com",
+            accepted_at=timezone.now(),
+            declined_at=timezone.now(),
+        )

--- a/tests/test_partner.py
+++ b/tests/test_partner.py
@@ -12,8 +12,9 @@ CourseOverviewTestModel has no `org` field, so `course_overview()` is mocked
 to avoid a FieldError and keep tests focused on the filter logic.
 """
 
-import pytest
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from tests.factories import make_organization, make_partner
 

--- a/tests/test_partner.py
+++ b/tests/test_partner.py
@@ -1,0 +1,52 @@
+"""
+Tests for Partner Course Offering (Suite 10).
+
+Covers Partner.get_partner_course_offering() in partner_catalog/models.py.
+
+Note: The actual implementation simply does:
+    CourseOverview.objects.filter(org=self.organization.short_name)
+There is no BaseCatalog involvement in this method — the test plan item
+"Returns courses from the BaseCatalog" is N/A for the current code.
+
+CourseOverviewTestModel has no `org` field, so `course_overview()` is mocked
+to avoid a FieldError and keep tests focused on the filter logic.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from tests.factories import make_organization, make_partner
+
+PATCH_COURSE_OVERVIEW = "partner_catalog.models.course_overview"
+
+
+@pytest.mark.django_db
+def test_get_partner_course_offering_filters_by_partner_org():
+    """get_partner_course_offering() queries CourseOverview filtered by the partner's org short_name."""
+    partner = make_partner()
+
+    mock_qs = MagicMock()
+    mock_model = MagicMock()
+    mock_model.objects.filter.return_value = mock_qs
+
+    with patch(PATCH_COURSE_OVERVIEW, return_value=mock_model):
+        result = partner.get_partner_course_offering()
+
+    mock_model.objects.filter.assert_called_once_with(org=partner.organization.short_name)
+    assert result is mock_qs
+
+
+@pytest.mark.django_db
+def test_get_partner_course_offering_does_not_include_other_orgs():
+    """get_partner_course_offering() does not filter by a different org's short_name."""
+    partner = make_partner()
+    other_org = make_organization()
+
+    mock_model = MagicMock()
+
+    with patch(PATCH_COURSE_OVERVIEW, return_value=mock_model):
+        partner.get_partner_course_offering()
+
+    call_kwargs = mock_model.objects.filter.call_args.kwargs
+    assert call_kwargs.get("org") == partner.organization.short_name
+    assert call_kwargs.get("org") != other_org.short_name

--- a/tests/test_partner_catalog_model.py
+++ b/tests/test_partner_catalog_model.py
@@ -1,0 +1,92 @@
+"""
+Tests for PartnerCatalog model (Suite 5).
+
+Covers:
+- PartnerCatalog.active property (date-based availability window)
+- PartnerCatalog.save() slug auto-generation
+"""
+
+import pytest
+from datetime import timedelta
+
+from django.utils import timezone
+from django.utils.text import slugify
+
+from partner_catalog.models import PartnerCatalog
+
+from tests.factories import make_catalog, make_organization, make_partner
+
+
+# ---------------------------------------------------------------------------
+# PartnerCatalog.active — date-based availability window
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_catalog_active_within_date_window():
+    """active is True when current date is between available_start_date and available_end_date."""
+    now = timezone.now()
+    catalog = make_catalog(
+        available_start_date=now - timedelta(days=1),
+        available_end_date=now + timedelta(days=1),
+    )
+
+    assert catalog.active is True
+
+
+@pytest.mark.django_db
+def test_catalog_inactive_before_start_date():
+    """active is False when current date is before available_start_date."""
+    now = timezone.now()
+    catalog = make_catalog(
+        available_start_date=now + timedelta(days=1),
+        available_end_date=now + timedelta(days=2),
+    )
+
+    assert catalog.active is False
+
+
+@pytest.mark.django_db
+def test_catalog_inactive_after_end_date():
+    """active is False when current date is after available_end_date."""
+    now = timezone.now()
+    catalog = make_catalog(
+        available_start_date=now - timedelta(days=2),
+        available_end_date=now - timedelta(days=1),
+    )
+
+    assert catalog.active is False
+
+
+# ---------------------------------------------------------------------------
+# PartnerCatalog.save() — slug auto-generation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_slug_auto_generated_when_not_provided():
+    """Slug is auto-generated from org short_name and catalog name when not provided."""
+    organization = make_organization(short_name="acme")
+    partner = make_partner(organization=organization)
+    catalog_name = "My Catalog"
+
+    catalog = make_catalog(partner=partner, name=catalog_name)
+
+    expected_slug = f"{slugify('acme')}-{slugify(catalog_name)}"
+    assert catalog.slug == expected_slug
+
+
+@pytest.mark.django_db
+def test_slug_not_overwritten_when_already_set():
+    """Slug is preserved on subsequent save() calls when already set."""
+    organization = make_organization(short_name="acme")
+    partner = make_partner(organization=organization)
+    custom_slug = "my-custom-slug"
+
+    catalog = make_catalog(partner=partner, slug=custom_slug)
+
+    # Trigger another save and verify slug is unchanged
+    catalog.name = "Updated Name"
+    catalog.save()
+
+    assert catalog.slug == custom_slug

--- a/tests/test_partner_catalog_model.py
+++ b/tests/test_partner_catalog_model.py
@@ -6,13 +6,11 @@ Covers:
 - PartnerCatalog.save() slug auto-generation
 """
 
-import pytest
 from datetime import timedelta
 
+import pytest
 from django.utils import timezone
 from django.utils.text import slugify
-
-from partner_catalog.models import PartnerCatalog
 
 from tests.factories import make_catalog, make_organization, make_partner
 

--- a/tests/test_partner_catalog_model.py
+++ b/tests/test_partner_catalog_model.py
@@ -14,7 +14,6 @@ from django.utils.text import slugify
 
 from tests.factories import make_catalog, make_organization, make_partner
 
-
 # ---------------------------------------------------------------------------
 # PartnerCatalog.active — date-based availability window
 # ---------------------------------------------------------------------------

--- a/tests/test_partner_catalog_model.py
+++ b/tests/test_partner_catalog_model.py
@@ -15,6 +15,7 @@ from django.utils.text import slugify
 from tests.factories import make_catalog, make_organization, make_partner
 
 
+
 # ---------------------------------------------------------------------------
 # PartnerCatalog.active — date-based availability window
 # ---------------------------------------------------------------------------

--- a/tests/test_partner_catalog_model.py
+++ b/tests/test_partner_catalog_model.py
@@ -15,7 +15,6 @@ from django.utils.text import slugify
 from tests.factories import make_catalog, make_organization, make_partner
 
 
-
 # ---------------------------------------------------------------------------
 # PartnerCatalog.active — date-based availability window
 # ---------------------------------------------------------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ match-dir = (?!migrations)
 
 [pytest]
 DJANGO_SETTINGS_MODULE = test_settings
-addopts = --cov partner_catalog --cov tests --cov-report term-missing --cov-report xml
+addopts = --no-migrations --cov partner_catalog --cov tests --cov-report term-missing --cov-report xml
 norecursedirs = .* docs requirements site-packages
 
 [testenv]


### PR DESCRIPTION
# Add README domain overview and enrollment license ADR

Rewrites the README with an actual description of the plugin domain (Partner → Catalog → Invitation → Learner → Enrollment), how the enrollment flow works, and a project layout reference. Also adds ADR 0002 documenting why `CatalogCourseEnrollment` is a single cross-catalog license and the tradeoffs of that design.
