### PR TITLE
fix: validate invitation capacity before acceptance and event emission

### DIFF
--- a/partner_catalog/consumers.py
+++ b/partner_catalog/consumers.py
@@ -56,6 +56,13 @@ def handle_catalog_learner_invitation_accepted(
 ) -> None:
     """Handle acceptance of a CatalogLearnerInvitation."""
     try:
+        if invitation.learner_id:
+            logger.info(
+                "CATALOG_LEARNER_INVITATION_ACCEPTED: Learner already linked for invitation id=%s learner_id=%s",
+                invitation.id,
+                invitation.learner_id,
+            )
+            return
 
         catalog_service = PartnerCatalogService()
         _, created = catalog_service.create_or_update_learner_from_invitation(invitation.id)

--- a/partner_catalog/services/invitations.py
+++ b/partner_catalog/services/invitations.py
@@ -21,8 +21,10 @@ from partner_catalog.events.signals import (
     CATALOG_LEARNER_INVITATION_DECLINED_V1,
     CATALOG_LEARNER_INVITATION_REMOVED_V1,
 )
+from partner_catalog.exceptions import InactiveCatalogEnrollment, UserLimitReached
 from partner_catalog.helpers.email import normalize_email
-from partner_catalog.models import CatalogLearnerInvitation
+from partner_catalog.models import CatalogLearner, CatalogLearnerInvitation
+from partner_catalog.policies.catalogs import has_catalog_capacity
 from partner_catalog.xapi.constants import (
     EVENT_NAME_INVITATION_ACCEPTED,
     EVENT_NAME_INVITATION_DECLINED,
@@ -158,17 +160,27 @@ class CatalogLearnerInvitationService:
     def accept_invitation(self, invitation_id: int, user):
         """
         Accept an existing CatalogLearnerInvitation.
-        Update status and timestamps accordingly.
+        Validate capacity/availability, update status, and create/update learner atomically.
         """
         invitation = self.get_invitation_or_raise(invitation_id)
-        return self._transition_status(
-            invitation=invitation,
-            new_status=Status.ACCEPTED,
-            user=user,
-            timestamp_field='accepted_at',
-            extra_updates={'user': user},
-            error_msg=self.ERROR_ACCEPT_NOT_ALLOWED,
-        )
+
+        if not self._is_status_transition_allowed(invitation, Status.ACCEPTED):
+            raise ValidationError(self.ERROR_ACCEPT_NOT_ALLOWED)
+
+        if not self._validate_invitation_status_access(user, invitation, Status.ACCEPTED):
+            raise ValidationError(self.ERROR_ACCEPT_NOT_ALLOWED)
+
+        self._validate_acceptance_preconditions(invitation=invitation, user=user)
+
+        invitation.accepted_at = timezone.now()
+        invitation.user = user
+        invitation.save()
+
+        self._create_or_update_learner_from_invitation(invitation)
+
+        invitation.refresh_from_db()
+        self._emit_invitation_event(invitation, actor_user_id=getattr(user, "id", None))
+        return invitation
 
     @transaction.atomic
     def remove_invitation(self, invitation_id: int, user):
@@ -191,9 +203,44 @@ class CatalogLearnerInvitationService:
         Get an invitation by ID or raise ValidationError if not found.
         """
         try:
-            return CatalogLearnerInvitation.objects.get(id=invitation_id)
+            return CatalogLearnerInvitation.objects.select_related("catalog").get(id=invitation_id)
         except CatalogLearnerInvitation.DoesNotExist as exc:
             raise ValidationError(self.ERROR_INVITATION_NOT_FOUND) from exc
+
+    def _validate_acceptance_preconditions(self, invitation: CatalogLearnerInvitation, user):
+        """
+        Validate catalog availability and learner capacity before accepting an invitation.
+        """
+        if not invitation.catalog.active:
+            raise InactiveCatalogEnrollment()
+
+        already_active = CatalogLearner.objects.filter(
+            catalog_id=invitation.catalog_id,
+            user_id=getattr(user, "id", None),
+            active=True,
+        ).exists()
+        if not already_active and not has_catalog_capacity(catalog=invitation.catalog):
+            raise UserLimitReached()
+
+    def _create_or_update_learner_from_invitation(self, invitation: CatalogLearnerInvitation):
+        """
+        Create or update the learner linked to an accepted invitation.
+
+        This mirrors the learner-linking semantics used by catalog services while
+        keeping acceptance flow self-contained to avoid circular imports.
+        """
+        learner, created = CatalogLearner.objects.get_or_create(
+            user_id=invitation.user_id,
+            catalog_id=invitation.catalog_id,
+            defaults={"current_invitation_id": invitation.id},
+        )
+
+        if not created and learner.current_invitation_id != invitation.id:
+            learner.current_invitation_id = invitation.id
+            learner.save()
+
+        invitation.learner = learner
+        invitation.save(update_fields=["learner"])
 
     def get_latest_sent_invitation(self, user, catalog):
         """

--- a/tests/test_invitation_service.py
+++ b/tests/test_invitation_service.py
@@ -12,9 +12,10 @@ from django.db import IntegrityError
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
+from partner_catalog.exceptions import UserLimitReached
 from partner_catalog.models import CatalogLearnerInvitation
 from partner_catalog.services.invitations import CatalogLearnerInvitationService
-from tests.factories import make_catalog, make_invitation, make_user
+from tests.factories import make_catalog, make_invitation, make_learner, make_user
 
 Status = CatalogLearnerInvitation.Status
 
@@ -135,6 +136,39 @@ def test_accept_invitation_raises_when_already_removed(service, catalog, learner
 
     with pytest.raises(ValidationError, match=service.ERROR_ACCEPT_NOT_ALLOWED):
         service.accept_invitation(invitation.id, user=learner_user)
+
+
+@pytest.mark.django_db
+def test_accept_invitation_raises_when_catalog_user_limit_reached(service, catalog, learner_user):
+    """
+    accept_invitation raises UserLimitReached when catalog capacity is exhausted and
+    must not leave the invitation in ACCEPTED state.
+    """
+    catalog.user_limit = 1
+    catalog.save(update_fields=["user_limit"])
+
+    existing_user = make_user(email="existing@example.com")
+    existing_invitation = make_invitation(
+        catalog,
+        user=existing_user,
+        invite_email=existing_user.email,
+        accepted_at=timezone.now(),
+    )
+    make_learner(catalog, existing_user, existing_invitation)
+
+    invitation = service.create_new_invitation(
+        invite_email=learner_user.email,
+        catalog_id=catalog.id,
+        emit_event=False,
+    )
+
+    with pytest.raises(UserLimitReached):
+        service.accept_invitation(invitation.id, user=learner_user)
+
+    invitation.refresh_from_db()
+    assert invitation.status == Status.SENT
+    assert invitation.accepted_at is None
+    assert invitation.learner_id is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

### Context
We found a bug where an invitation could be marked as **Accepted** even when the catalog had no available learner slots. In those cases, learner creation failed later, so frontend/backend state became inconsistent.

### Root cause
The `accept_invitation` flow persisted `accepted_at` and emitted the accepted event first, and capacity validation happened later in the accepted-event consumer path.  
Because event dispatch is robust, receiver exceptions did not rollback the already persisted invitation status.

### What changed

1. `partner_catalog/services/invitations.py`
- Refactored `accept_invitation` to:
  - Validate transition/access rules.
  - Validate preconditions **before** acceptance:
    - catalog availability (`InactiveCatalogEnrollment`)
    - learner capacity (`UserLimitReached`)
  - Persist acceptance and create/update/link `CatalogLearner` in the same transaction.
  - Emit events only after the acceptance + learner linkage succeeds.
- Added private helper methods:
  - `_validate_acceptance_preconditions(...)`
  - `_create_or_update_learner_from_invitation(...)`
- Removed function-level import that caused lint issues (`import-outside-toplevel`) and cyclic import warnings.

2. `partner_catalog/consumers.py`
- Updated accepted-invitation consumer to short-circuit when `learner_id` is already present in event data, avoiding redundant learner creation attempts.
- Normalized line endings to fix lint (`mixed-line-endings`).

3. `tests/test_invitation_service.py`
- Added regression test:
  - When `user_limit` is reached, `accept_invitation` raises `UserLimitReached`.
  - Invitation remains `SENT` (`accepted_at is None`, `learner_id is None`).

### Result
Acceptance now fails early with the correct API error (e.g., HTTP 409 for `UserLimitReached`), and no invitation is incorrectly marked as accepted when capacity is exhausted.