### PR TITLE
fix(admin): keep base_catalog pre-filled after save and add another

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,4 +14,4 @@ Change Log
 Unreleased
 **********
 
-*
+* fix(admin): keep base_catalog pre-filled after "Save and add another" in BaseCatalogCourseAdmin

--- a/partner_catalog/admin.py
+++ b/partner_catalog/admin.py
@@ -1,7 +1,10 @@
 """Admin configuration for Partner Catalog models."""
 
+from urllib.parse import urlencode
+
 from django.contrib import admin
 from django.db.models import Count
+from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.html import format_html
 
@@ -118,6 +121,24 @@ class BaseCatalogCourseAdmin(admin.ModelAdmin):
         if not change and not obj.added_by:
             obj.added_by = request.user
         super().save_model(request, obj, form, change)
+
+    def response_add(self, request, obj, post_url_continue=None):
+        """After saving a new entry, keep base_catalog pre-filled when adding another."""
+        response = super().response_add(request, obj, post_url_continue)
+        if "_addanother" in request.POST and obj.base_catalog_id:
+            add_url = reverse(
+                f"admin:{self.model._meta.app_label}_{self.model._meta.model_name}_add"
+            )
+            query = urlencode({"base_catalog": obj.base_catalog_id})
+            return HttpResponseRedirect(f"{add_url}?{query}")
+        return response
+
+    def get_changeform_initial_data(self, request):
+        """Pre-populate base_catalog from query-string when coming from response_add."""
+        initial = super().get_changeform_initial_data(request)
+        if "base_catalog" in request.GET and "base_catalog" not in initial:
+            initial["base_catalog"] = request.GET["base_catalog"]
+        return initial
 
     def get_queryset(self, request):
         """Optimize queryset with select_related."""

--- a/tests/admin_test_urls.py
+++ b/tests/admin_test_urls.py
@@ -1,7 +1,7 @@
 """Minimal URL conf for admin-related tests that need reverse('admin:...')."""
 
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import path
 
 urlpatterns = [
     path("admin/", admin.site.urls),

--- a/tests/admin_test_urls.py
+++ b/tests/admin_test_urls.py
@@ -1,0 +1,8 @@
+"""Minimal URL conf for admin-related tests that need reverse('admin:...')."""
+
+from django.contrib import admin
+from django.urls import include, path
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+]

--- a/tests/test_admin_base_catalog_course.py
+++ b/tests/test_admin_base_catalog_course.py
@@ -14,7 +14,6 @@ from django.test import RequestFactory, override_settings
 from partner_catalog.admin import BaseCatalogCourseAdmin
 from partner_catalog.edxapp_wrapper.course_module import course_overview
 from partner_catalog.models import BaseCatalog, BaseCatalogCourse
-
 from tests.factories import make_user
 
 _ADMIN_URL_CONF = "tests.admin_test_urls"

--- a/tests/test_admin_base_catalog_course.py
+++ b/tests/test_admin_base_catalog_course.py
@@ -1,0 +1,128 @@
+"""
+Tests for BaseCatalogCourseAdmin sticky base_catalog behaviour.
+
+When the user clicks "Save and add another" after creating a BaseCatalogCourse,
+the redirect URL should carry the same base_catalog ID so that the next add-form
+comes pre-populated.
+"""
+
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.test import RequestFactory, override_settings
+
+from partner_catalog.admin import BaseCatalogCourseAdmin
+from partner_catalog.edxapp_wrapper.course_module import course_overview
+from partner_catalog.models import BaseCatalog, BaseCatalogCourse
+
+from tests.factories import make_user
+
+_ADMIN_URL_CONF = "tests.admin_test_urls"
+
+CourseOverview = course_overview()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_course():
+    return CourseOverview.objects.create()
+
+
+def _make_base_catalog(name="Test Base Catalog"):
+    return BaseCatalog.objects.create(name=name, slug=name.lower().replace(" ", "-"))
+
+
+def _post_request(user, data=None):
+    factory = RequestFactory()
+    request = factory.post("/fake-admin/", data=data or {})
+    request.user = user
+    request.session = {}
+    request._messages = FallbackStorage(request)
+    return request
+
+
+def _get_request(user, params=None):
+    factory = RequestFactory()
+    query = f"?{params}" if params else ""
+    request = factory.get(f"/fake-admin/{query}")
+    request.user = user
+    request.session = {}
+    request._messages = FallbackStorage(request)
+    return request
+
+
+def _admin_view():
+    return BaseCatalogCourseAdmin(BaseCatalogCourse, AdminSite())
+
+
+# ---------------------------------------------------------------------------
+# response_add — redirect preserves base_catalog when "_addanother" posted
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF=_ADMIN_URL_CONF)
+def test_response_add_addanother_redirects_with_base_catalog():
+    """Clicking 'Save and add another' redirects to the add URL with base_catalog param."""
+    admin_user = make_user(is_staff=True, is_superuser=True)
+    catalog = _make_base_catalog()
+    course = _make_course()
+    entry = BaseCatalogCourse.objects.create(
+        base_catalog=catalog,
+        course_overview=course,
+        added_by=admin_user,
+    )
+
+    request = _post_request(admin_user, data={"_addanother": "1"})
+    response = _admin_view().response_add(request, entry)
+
+    assert response.status_code == 302
+    assert f"base_catalog={catalog.pk}" in response["Location"]
+
+
+@pytest.mark.django_db
+@override_settings(ROOT_URLCONF=_ADMIN_URL_CONF)
+def test_response_add_save_does_not_add_base_catalog_param():
+    """A plain 'Save' (no _addanother) does not append base_catalog to the redirect."""
+    admin_user = make_user(is_staff=True, is_superuser=True)
+    catalog = _make_base_catalog()
+    course = _make_course()
+    entry = BaseCatalogCourse.objects.create(
+        base_catalog=catalog,
+        course_overview=course,
+        added_by=admin_user,
+    )
+
+    request = _post_request(admin_user, data={})
+    response = _admin_view().response_add(request, entry)
+
+    assert response.status_code == 302
+    assert "base_catalog" not in response["Location"]
+
+
+# ---------------------------------------------------------------------------
+# get_changeform_initial_data — pre-populates from GET param
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_get_changeform_initial_data_sets_base_catalog_from_get():
+    """GET ?base_catalog=<id> pre-populates the initial form data."""
+    admin_user = make_user(is_staff=True, is_superuser=True)
+    catalog = _make_base_catalog()
+
+    request = _get_request(admin_user, params=f"base_catalog={catalog.pk}")
+    initial = _admin_view().get_changeform_initial_data(request)
+
+    assert str(initial.get("base_catalog")) == str(catalog.pk)
+
+
+@pytest.mark.django_db
+def test_get_changeform_initial_data_without_param_is_empty():
+    """Without a GET param, base_catalog is absent from initial data."""
+    admin_user = make_user(is_staff=True, is_superuser=True)
+
+    request = _get_request(admin_user)
+    initial = _admin_view().get_changeform_initial_data(request)
+
+    assert "base_catalog" not in initial

--- a/tests/test_admin_base_catalog_course.py
+++ b/tests/test_admin_base_catalog_course.py
@@ -27,29 +27,33 @@ CourseOverview = course_overview()
 # ---------------------------------------------------------------------------
 
 def _make_course():
+    """Create and return a CourseOverview instance."""
     return CourseOverview.objects.create()
 
 
 def _make_base_catalog(name="Test Base Catalog"):
+    """Create and return a BaseCatalog with the given name."""
     return BaseCatalog.objects.create(name=name, slug=name.lower().replace(" ", "-"))
 
 
 def _post_request(user, data=None):
+    """Build a POST request with messages middleware attached."""
     factory = RequestFactory()
     request = factory.post("/fake-admin/", data=data or {})
     request.user = user
     request.session = {}
-    request._messages = FallbackStorage(request)
+    request._messages = FallbackStorage(request)  # pylint: disable=protected-access
     return request
 
 
 def _get_request(user, params=None):
+    """Build a GET request with messages middleware attached."""
     factory = RequestFactory()
     query = f"?{params}" if params else ""
     request = factory.get(f"/fake-admin/{query}")
     request.user = user
     request.session = {}
-    request._messages = FallbackStorage(request)
+    request._messages = FallbackStorage(request)  # pylint: disable=protected-access
     return request
 
 


### PR DESCRIPTION
#  sticky base_catalog on "Save and add another"

Keep the **Base catalog** field pre-filled when an admin clicks
"Save and add another" in the `BaseCatalogCourse` admin page.

## Context

Related issue: [sticky base_catalog after save-and-add-another in
`/admin/partner_catalog/basecatalog/`](https://github.com/fccn/nau-technical/issues/940).

When adding multiple courses to the same `BaseCatalog` one by one,
clicking "Save and add another" redirected to a blank add form,
forcing the user to re-select the catalog every time. The only
workarounds were going back to the previous page or copy-pasting
the catalog ID manually.

## Root cause

Django admin's default `response_add` redirect to `/add/` does not
carry any query parameters, so the `base_catalog` raw-id field is
always empty on the next form load.

## Change

Two small overrides added to `BaseCatalogCourseAdmin` in
`partner_catalog/admin.py`:

- **`response_add`** — when `_addanother` is in the POST data,
  redirects to `/add/?base_catalog=<id>` instead of the plain `/add/`,
  preserving the catalog that was just used.
- **`get_changeform_initial_data`** — reads the `base_catalog` GET
  parameter and injects it into the form's initial data so the
  raw-id widget renders with the value already set.
