### PR TITLE
fix: defer invitation email task until after DB transaction commits

### DIFF
--- a/partner_catalog/consumers.py
+++ b/partner_catalog/consumers.py
@@ -8,7 +8,7 @@ when relevant events occur.
 import logging
 from typing import Any
 
-from django.db import DatabaseError
+from django.db import DatabaseError, transaction
 from django.dispatch import receiver
 from rest_framework.exceptions import ValidationError
 
@@ -33,19 +33,25 @@ def handle_catalog_learner_invitation_created(
     **_kwargs: Any
 ) -> None:
     """Handle creation of a CatalogLearnerInvitation."""
-    # Enqueue email sending to Celery worker (do not send inline).
-    try:
-        logger.info(
-            "Enqueueing invitation created email: id=%s catalog_id=%s",
-            invitation.id,
-            invitation.catalog_id,
-        )
-        send_catalog_invitation_created_email.delay(invitation.id)
-    except Exception:  # pragma: no cover - defensive logging  # pylint: disable=broad-exception-caught
-        logger.exception(
-            "Failed to enqueue invitation created email for id=%s",
-            getattr(invitation, "id", None),
-        )
+    # Defer email task until after the current DB transaction commits so the
+    # Celery worker is guaranteed to find the invitation record in the database.
+    invitation_id = invitation.id
+    logger.info(
+        "Scheduling invitation created email after commit: id=%s catalog_id=%s",
+        invitation_id,
+        invitation.catalog_id,
+    )
+
+    def _send_email():
+        try:
+            send_catalog_invitation_created_email.delay(invitation_id)
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.exception(
+                "Failed to enqueue invitation created email for id=%s",
+                invitation_id,
+            )
+
+    transaction.on_commit(_send_email)
 
 
 @receiver(CATALOG_LEARNER_INVITATION_ACCEPTED_V1)


### PR DESCRIPTION
# Fix catalog invitation emails not being delivered

## Summary

Invitation emails were silently dropped: the system confirmed "sent" on the
API response, but recipients never received anything. The root cause was a
race condition between the database transaction and the Celery task dispatch.

---

## Root cause

`handle_catalog_learner_invitation_created` in `consumers.py` was calling
`send_catalog_invitation_created_email.delay(invitation.id)` **inside** the
`@transaction.atomic` block that wraps the invitation creation in
`CatalogLearnerInvitationService`.

Django signals fire synchronously before the transaction commits. So the
Celery worker could — and regularly did — pick up the task and query the
database for the invitation **before the row existed**, resulting in a
`DoesNotExist` exception and a failed email delivery. The API response
still returned `201` because the exception was swallowed after retries.

```
Request → @transaction.atomic {
    create invitation row    ← not yet visible to other connections
    emit signal              ← fires HERE, inside the transaction
        → .delay(id)         ← worker picks up task immediately
            → SELECT ... WHERE id=?  ← row not found yet → DoesNotExist
} → COMMIT                   ← too late, task already failed
```

---

## Fix

Wrap the Celery dispatch in `transaction.on_commit` so it is only enqueued
**after** the database transaction successfully commits and the invitation
row is guaranteed to be visible to all connections, including the worker:

```python
transaction.on_commit(
    lambda: send_catalog_invitation_created_email.delay(invitation_id)
)
```

The `invitation_id` is captured before the lambda to avoid a closure over
a mutable attribute.