### PR TITLE
feat: add extra user info to invitations and extra info

### DIFF
--- a/partner_catalog/api/v1/filters.py
+++ b/partner_catalog/api/v1/filters.py
@@ -3,7 +3,7 @@
 import django_filters
 from rest_framework.filters import OrderingFilter
 
-from partner_catalog.models import Partner, PartnerCatalog
+from partner_catalog.models import CatalogLearnerInvitation, Partner, PartnerCatalog
 
 
 class PartnerFilter(django_filters.FilterSet):
@@ -53,6 +53,45 @@ class PartnerCatalogFilter(django_filters.FilterSet):
         fields = [
             "partner",
         ]
+
+
+class CatalogLearnerInvitationFilter(django_filters.FilterSet):
+    """
+    Custom filters for CatalogLearnerInvitation model.
+
+    Allows filtering by:
+    - status: one or more comma-separated status display names
+      (e.g. "sent" or "sent,accepted"), case-insensitive.
+    - user: user ID
+    """
+
+    status = django_filters.CharFilter(
+        method="filter_status",
+        help_text="Filter by invitation status name(s), comma-separated (e.g. 'sent,accepted').",
+    )
+
+    class Meta:
+        model = CatalogLearnerInvitation
+        fields = [
+            "status",
+            "user",
+        ]
+
+    def filter_status(self, queryset, name, value):  # pylint: disable=unused-argument
+        """Filter by one or more case-insensitive status display names."""
+        status_by_label = {
+            label.lower(): status_value
+            for status_value, label in CatalogLearnerInvitation.Status.choices
+        }
+        statuses = [
+            status_by_label[part]
+            for part in (item.strip().lower() for item in value.split(","))
+            if part in status_by_label
+        ]
+
+        if not statuses:
+            return queryset.none()
+        return queryset.filter(status__in=statuses)
 
 
 class CatalogCourseOrderingFilter(OrderingFilter):

--- a/partner_catalog/api/v1/serializers.py
+++ b/partner_catalog/api/v1/serializers.py
@@ -416,6 +416,40 @@ class CatalogLearnerInvitationSerializer(serializers.ModelSerializer):
         return obj.get_status_display()
 
 
+class CatalogLearnerInvitationListSerializer(serializers.ModelSerializer):
+    """
+    Read-only serializer for the manager-facing learners view.
+
+    Lists each catalog member through their current invitation status.
+    ``user`` is null for pending invitations sent to emails without a registered account.
+    """
+
+    catalog_id = serializers.IntegerField(read_only=True)
+    learner_id = serializers.IntegerField(read_only=True)
+    user = UserSimpleSerializer(read_only=True)
+    status = serializers.CharField(source="get_status_display", read_only=True)
+    enrollments = serializers.IntegerField(source="enrollments_count", read_only=True)
+    certified = serializers.IntegerField(source="certified_count", read_only=True)
+
+    class Meta:
+        model = CatalogLearnerInvitation
+        fields = [
+            "id",
+            "catalog_id",
+            "learner_id",
+            "user",
+            "invite_email",
+            "status",
+            "invited_at",
+            "accepted_at",
+            "declined_at",
+            "removed_at",
+            "enrollments",
+            "certified",
+        ]
+        read_only_fields = fields
+
+
 class CatalogCourseEnrollmentSerializer(serializers.ModelSerializer):
     """Serializer for enrollments in a catalog course."""
 

--- a/partner_catalog/api/v1/views.py
+++ b/partner_catalog/api/v1/views.py
@@ -1,6 +1,7 @@
 """Partner Catalog API v1 Views."""
 
 from django.db.models import Count, F, OuterRef, Q, Subquery
+from django.db.models.functions import Coalesce
 from django_filters.rest_framework import DjangoFilterBackend
 from edx_rest_framework_extensions.permissions import IsAuthenticated, IsStaff, IsSuperuser
 from rest_framework import filters, mixins, status, viewsets
@@ -9,7 +10,12 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
 
-from partner_catalog.api.v1.filters import CatalogCourseOrderingFilter, PartnerCatalogFilter, PartnerFilter
+from partner_catalog.api.v1.filters import (
+    CatalogCourseOrderingFilter,
+    CatalogLearnerInvitationFilter,
+    PartnerCatalogFilter,
+    PartnerFilter,
+)
 from partner_catalog.api.v1.mixins import InjectNestedFKMixin
 from partner_catalog.api.v1.schemas import (
     add_courses_schema,
@@ -23,6 +29,7 @@ from partner_catalog.api.v1.serializers import (
     BulkRemoveInvitationSerializer,
     CatalogCourseEnrollmentSerializer,
     CatalogCourseSerializer,
+    CatalogLearnerInvitationListSerializer,
     CatalogLearnerInvitationSerializer,
     CatalogLearnerSerializer,
     InvitationActionSerializer,
@@ -45,6 +52,7 @@ from partner_catalog.services.catalogs import PartnerCatalogService
 from partner_catalog.services.certificates import (
     annotate_catalog_certified_count,
     annotate_course_certified_count,
+    annotate_invitation_certified_count,
     annotate_learner_certified_count,
     annotate_partner_certified_count,
 )
@@ -394,20 +402,61 @@ class CatalogCourseViewSet(
 
 
 class CatalogLearnerInvitationViewSet(
+    CSVExportMixin,
     mixins.ListModelMixin,
     mixins.CreateModelMixin,
     viewsets.GenericViewSet,
     InjectNestedFKMixin,
 ):
-    """ViewSet for managing Catalog Learner Invitations."""
+    """
+    ViewSet for managing Catalog Learner Invitations.
+
+    The list action is the manager-facing catalog roster: it returns each
+    member's current invitation (accepted or removed) plus pending (sent)
+    invitations, so learners appear in the table before accepting.
+    """
 
     queryset = CatalogLearnerInvitation.objects.select_related("catalog", "user")
     service = CatalogLearnerInvitationService()
+
+    csv_filename = "learners_report.csv"
+    csv_fields = [
+        "user.full_name", "invite_email", "status", "invited_at",
+        "accepted_at", "user.last_login", "enrollments", "certified", "removed_at",
+    ]
+    csv_labels = {
+        "user.full_name": "Full Name",
+        "invite_email": "Email",
+        "status": "Status",
+        "invited_at": "Invite Sent At",
+        "accepted_at": "Accepted At",
+        "user.last_login": "Last Login",
+        "enrollments": "Enrollments",
+        "certified": "Certified",
+        "removed_at": "Removed At",
+    }
     filter_backends = [
         DjangoFilterBackend,
         filters.SearchFilter,
         filters.OrderingFilter,
     ]
+    filterset_class = CatalogLearnerInvitationFilter
+    search_fields = [
+        "invite_email",
+        "user__username",
+        "user__first_name",
+        "user__last_name",
+        "user__email",
+    ]
+    ordering_fields = [
+        "id",
+        "status",
+        "invited_at",
+        "accepted_at",
+        "removed_at",
+        "user__last_login",
+    ]
+    ordering = ["id"]
 
     # Mixin config
     nested_lookup_kwarg = "catalog_pk"
@@ -421,17 +470,48 @@ class CatalogLearnerInvitationViewSet(
         if catalog_pk:
             qs = qs.filter(catalog_id=catalog_pk)
 
+        if self.action == "list":
+            qs = self._annotate_roster(qs)
+
         return qs
+
+    def _annotate_roster(self, qs):
+        """Scope the queryset to roster rows and annotate aggregate counts.
+
+        Roster rows are invitations that are the current invitation of a
+        learner, or still pending (sent). Superseded history rows (declined,
+        failed, re-invited) are excluded.
+        """
+        qs = qs.filter(
+            Q(current_for_learner__isnull=False)
+            | Q(status=CatalogLearnerInvitation.Status.SENT)
+        )
+
+        enrollments_subquery = CatalogCourseEnrollment.objects.filter(
+            user_id=OuterRef("user_id"),
+            catalog_course__catalog_id=OuterRef("catalog_id"),
+            active=True,
+        ).values("user_id").annotate(count=Count("id")).values("count")
+
+        qs = qs.annotate(enrollments_count=Coalesce(Subquery(enrollments_subquery), 0))
+        qs = annotate_invitation_certified_count(qs)
+        return qs
+
+    def get_permissions(self):
+        """Instantiate permissions from the action-dependent permission classes."""
+        return [permission() for permission in self.get_permission_classes()]
 
     def get_permission_classes(self):
         """Get permission classes based on action."""
 
         base_permissions = [IsAuthenticated]
         manager_actions = [
+            "list",
             "create",
             "remove_invite",
-            "bulk_invite_upload",
-            "bulk_remove_upload"
+            "bulk_invite",
+            "bulk_remove",
+            "bulk_invite_status",
         ]
         if self.action in manager_actions:
             return base_permissions + [IsPartnerCatalogManager]
@@ -440,6 +520,8 @@ class CatalogLearnerInvitationViewSet(
     def get_serializer_class(self):
         """Get the serializer class based on action."""
 
+        if self.action == "list":
+            return CatalogLearnerInvitationListSerializer
         if self.action in [
             "accept_invite",
             "decline_invite",
@@ -448,7 +530,7 @@ class CatalogLearnerInvitationViewSet(
             "bulk_invite_status",
         ]:
             return InvitationActionSerializer
-        elif self.action == "bulk_remove":
+        if self.action == "bulk_remove":
             return BulkRemoveInvitationSerializer
 
         return CatalogLearnerInvitationSerializer

--- a/partner_catalog/services/certificates.py
+++ b/partner_catalog/services/certificates.py
@@ -4,7 +4,7 @@ from django.db.models import Case, Count, Exists, IntegerField, OuterRef, Subque
 from django.db.models.functions import Coalesce
 
 from partner_catalog.edxapp_wrapper.certificates_module import certificate_statuses_model, generated_certificate_model
-from partner_catalog.models import CatalogCourse, CatalogCourseEnrollment, CatalogLearner
+from partner_catalog.models import CatalogCourse, CatalogCourseEnrollment, CatalogLearner, CatalogLearnerInvitation
 
 CertificateStatuses = certificate_statuses_model()
 GeneratedCertificate = generated_certificate_model()
@@ -89,6 +89,28 @@ def annotate_learner_certified_count(qs):
 
     annotated = annotate_certified_count(qs, users_qs, courses_qs)
     return annotated
+
+
+def annotate_invitation_certified_count(qs):
+    """Annotate a CatalogLearnerInvitation queryset with certified_count.
+
+    It gets the count of certificates for the invited user in courses that
+    belong to the invitation's catalog. Pending invitations without a linked
+    user resolve to 0 since no certificates can match a null user.
+    """
+    users_qs = CatalogLearnerInvitation.objects.filter(
+        pk=OuterRef("pk"),
+    ).values("user_id")
+
+    catalog_id_sq = CatalogLearnerInvitation.objects.filter(
+        pk=OuterRef("pk"),
+    ).values("catalog_id")
+
+    courses_qs = CatalogCourse.objects.filter(
+        catalog_id__in=Subquery(catalog_id_sq),
+    ).values("course_overview__id")
+
+    return annotate_certified_count(qs, users_qs, courses_qs)
 
 
 def annotate_certified_count(qs, users_qs, courses_qs):


### PR DESCRIPTION
### Summary

The manager `learners` table previously listed `CatalogLearner` records, which only exist after an invitation is accepted, `pending` invitations were invisible. The invitations list endpoint (`manage/catalogs/{id}/invitations/`) is now the manager-facing roster: it returns each member's current invitation (accepted or removed) plus pending (sent) invitations, so invited users appear with a pending status before accepting.


## What changed

- `CatalogLearnerInvitationViewSet`
   - `list` returns roster rows scoped by `Q(current_for_learner__isnull=False) | Q(status=SENT)`. Superseded history rows (declined, failed, re-invited) are excluded; the current_invitation OneToOne guarantees one row per member, and the existing cla_unique_active_invitation constraint guarantees at most one pending row per email.
  - Rows are annotated with `enrollments_count` (active CatalogCourseEnrollment subquery) and `certified_count` (new `annotate_invitation_certified_count` in `services/certificates.py`).
  - Added filtering (`CatalogLearnerInvitationFilter`: status by comma-separated names, user), search (invite_email + user fields), ordering, and CSV export (learners_report.csv) matching the previous learners report columns.
- New `CatalogLearnerInvitationListSerializer` (read-only): nested user (null for pending invites to unregistered emails), learner_id, invite_email, status display string, timestamps, enrollments, certified.
- Permissions fix: `get_permission_classes()` was dead code — DRF never calls it, so the intended action gating was not applied and the invitations list was readable by any authenticated user (email disclosure). Now wired via get_permissions(), with list manager-gated. Also corrected manager_actions entries that didn't match real action names (bulk_invite_upload/bulk_remove_upload → bulk_invite/bulk_remove) and added bulk_invite_status.


**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
